### PR TITLE
hotfix: fix parse_price() integer+frac math + clarify threshold_spread

### DIFF
--- a/crates/gateway-ws/src/lib.rs
+++ b/crates/gateway-ws/src/lib.rs
@@ -183,34 +183,24 @@ impl GatewayWs {
     }
 
     /// Parse a price string to Fixed64 without allocating.
+    ///
+    /// Correctly separates integer and fractional parts so that
+    /// "50000.12345678" → `Fixed64::from_raw(5_000_012_345_678)`.
     #[inline(always)]
     pub fn parse_price(s: &str) -> Fixed64 {
-        // Use fixed-point parsing: string → u64 * 1e8
-        // Simple implementation: find decimal point and compute
-        let bytes = s.as_bytes();
-        let mut val: u64 = 0;
-        let mut frac_digits: u32 = 0;
+        const SCALE: u64 = 100_000_000; // 1e8
 
-        for &b in bytes {
-            if b == b'.' {
-                continue;
-            }
-            if b.is_ascii_digit() {
-                let d = (b - b'0') as u64;
-                val = val * 10 + d;
-                frac_digits += 1;
-            }
-        }
-
-        if frac_digits >= 8 {
-            // Enough or more decimals — shift right
-            let shift = frac_digits - 8;
-            Fixed64::from_raw(val / 10u64.pow(shift))
+        let dot_pos = s.find('.');
+        let int_part: u64 = s[..dot_pos.unwrap_or(s.len())].parse().unwrap_or(0);
+        let frac_raw: u64 = if let Some(d) = dot_pos {
+            let frac_str = &s[d + 1..];
+            let digits = frac_str.len().min(8);
+            let val: u64 = frac_str[..digits].parse().unwrap_or(0);
+            val * 10u64.pow((8 - digits) as u32)
         } else {
-            // Pad with zeros on the right
-            let mul = 10u64.pow(8 - frac_digits);
-            Fixed64::from_raw(val * mul)
-        }
+            0
+        };
+        Fixed64::from_raw(int_part * SCALE + frac_raw)
     }
 }
 

--- a/crates/gateway-ws/tests/parse_price_test.rs
+++ b/crates/gateway-ws/tests/parse_price_test.rs
@@ -1,0 +1,67 @@
+use gateway_ws::GatewayWs;
+use types::Fixed64;
+
+/// Regression test for critical price parsing bug (Masami review 2026-03-28).
+/// parse_price was counting ALL digits as frac_digits instead of only post-decimal.
+/// "50000.12345678" returned 50_000_123 raw instead of 5_000_012_345_678.
+
+#[test]
+fn parse_price_basic_integer() {
+    // "50000" → 50000 * 1e8 = 5_000_000_000_000
+    let p = GatewayWs::parse_price("50000");
+    assert_eq!(p.raw(), 5_000_000_000_000, "integer price");
+}
+
+#[test]
+fn parse_price_8_decimal_places() {
+    // "50000.12345678" → 5_000_012_345_678
+    let p = GatewayWs::parse_price("50000.12345678");
+    assert_eq!(p.raw(), 5_000_012_345_678, "8 decimal places");
+}
+
+#[test]
+fn parse_price_fewer_decimals() {
+    // "50000.5" → 50000 * 1e8 + 5 * 1e7 = 5_000_050_000_000
+    let p = GatewayWs::parse_price("50000.5");
+    assert_eq!(p.raw(), 5_000_050_000_000, "1 decimal place");
+}
+
+#[test]
+fn parse_price_two_decimals() {
+    // "1.23" → 1 * 1e8 + 23 * 1e6 = 123_000_000
+    let p = GatewayWs::parse_price("1.23");
+    assert_eq!(p.raw(), 123_000_000, "2 decimal places");
+}
+
+#[test]
+fn parse_price_zero_fractional() {
+    // "100.00000000" → 10_000_000_000
+    let p = GatewayWs::parse_price("100.00000000");
+    assert_eq!(p.raw(), 10_000_000_000, "zero frac");
+}
+
+#[test]
+fn parse_price_small_price() {
+    // "0.00010000" → 10_000 raw (BTC sat-level price)
+    let p = GatewayWs::parse_price("0.00010000");
+    assert_eq!(p.raw(), 10_000, "small price 0.0001");
+}
+
+#[test]
+fn parse_price_truncates_beyond_8_decimals() {
+    // "1.123456789" → truncate at 8 digits → "12345678" → 1_123_456_780 raw
+    // (last digit 9 is dropped)
+    let p = GatewayWs::parse_price("1.123456789");
+    assert_eq!(p.raw(), 112_345_678, "truncate >8 decimals");
+}
+
+#[test]
+fn parse_price_regression_was_wrong() {
+    // This is the exact case that was broken:
+    // Old code produced 50_000_123 (counted int+frac digits as frac_digits=13, shift by 5 → /100000)
+    // Correct value: 5_000_012_345_678
+    let p = GatewayWs::parse_price("50000.12345678");
+    let old_wrong = Fixed64::from_raw(50_000_123);
+    assert_ne!(p.raw(), old_wrong.raw(), "must not produce old wrong value");
+    assert_eq!(p.raw(), 5_000_012_345_678);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,10 @@ async fn main() -> anyhow::Result<()> {
 
     // Build engine
     let engine = Arc::new(engine::Engine::<20, 20>::new());
-    let strategy = strategy::Strategy::new(Arc::clone(&engine), 50_000_000); // 50bps = 0.5%
+    // threshold_spread_raw is an ABSOLUTE spread in Fixed64 raw units (1e8 = 1 USDT).
+    // 50bps on BTC ~50k = $250 = 25_000_000_000 raw.
+    // In paper mode this is just a signal threshold — no real orders.
+    let strategy = strategy::Strategy::new(Arc::clone(&engine), 25_000_000_000);
 
     // Build frontend broadcaster
     let frontend = Arc::new(frontend_ws::FrontendWs::new());


### PR DESCRIPTION
## Critical hotfix — reported by Masami (post-merge audit PR #7)

### 🔴 CRITICAL: parse_price() was wrong by ~100,000x

**Root cause:** The loop counted ALL digits (integer + fractional) as `frac_digits`, then divided by `10^(frac_digits-8)`. For `"50000.12345678"` with 13 total digits → shift 5 → produced `50_000_123` raw instead of `5_000_012_345_678`. Every price on the hot path was wrong. Live mode would have caused instant losses.

**Fix:** Split on `.`, parse integer and fractional parts independently:
```rust
let dot_pos = s.find('.');
let int_part: u64 = s[..dot_pos.unwrap_or(s.len())].parse().unwrap_or(0);
let frac_raw: u64 = if let Some(d) = dot_pos {
    let frac_str = &s[d+1..];
    let digits = frac_str.len().min(8);
    let val: u64 = frac_str[..digits].parse().unwrap_or(0);
    val * 10u64.pow((8 - digits) as u32)
} else { 0 };
Fixed64::from_raw(int_part * SCALE + frac_raw)
```

### 🟠 MAJOR: threshold_spread was mislabelled

`50_000_000` was commented as "50bps = 0.5%" but `check_spread` uses **absolute raw units** (1 USDT = 100_000_000). The value was 0.50 USDT, 500x below the intended 50bps (~$250 on BTC). Updated to `25_000_000_000` (= $250) with explicit comment.

### Tests added

8 regression tests in `crates/gateway-ws/tests/parse_price_test.rs`:
- Integer, 8-decimal, fewer decimals, truncate >8 decimals
- `parse_price_regression_was_wrong` — explicitly checks old broken value is NOT returned

All 20 workspace tests pass. Clippy clean (-D warnings).