### PR TITLE
feat(#5): risk management + kill switch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -185,6 +185,7 @@ dependencies = [
  "gateway-ws",
  "health",
  "parking_lot",
+ "risk",
  "serde",
  "serde_json",
  "strategy",
@@ -508,6 +509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "risk"
+version = "0.1.0"
+dependencies = [
+ "parking_lot",
+ "serde",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -664,6 +675,7 @@ version = "0.1.0"
 dependencies = [
  "engine",
  "parking_lot",
+ "risk",
  "tracing",
  "types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/types", "crates/gateway-ws", "crates/engine", "crates/strategy", "crates/frontend-ws", "crates/order-manager", "crates/health"]
+members = ["crates/types", "crates/gateway-ws", "crates/engine", "crates/strategy", "crates/frontend-ws", "crates/order-manager", "crates/health", "crates/risk"]
 
 [package]
 name = "gate-arb"
@@ -22,6 +22,7 @@ frontend-ws = { path = "crates/frontend-ws" }
 strategy = { path = "crates/strategy" }
 gateway-ws = { path = "crates/gateway-ws" }
 health = { path = "crates/health" }
+risk = { path = "crates/risk" }
 types = { path = "crates/types" }
 
 [[bin]]

--- a/crates/risk/Cargo.toml
+++ b/crates/risk/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "risk"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+parking_lot = "0.12"
+serde = { version = "1", features = ["derive"] }
+tracing = "0.1"
+
+[dev-dependencies]
+serde_json = "1"

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -32,22 +32,23 @@ impl Default for RiskConfig {
 
 impl RiskConfig {
     pub fn from_env() -> Self {
+        let defaults = RiskConfig::default();
         Self {
             max_drawdown_raw: std::env::var("GATE_MAX_DRAWDOWN_USD")
                 .ok()
                 .and_then(|v| v.parse::<f64>().ok())
                 .map(|v| (v * 1e8_f64) as i64)
-                .unwrap_or_default(),
+                .unwrap_or(defaults.max_drawdown_raw), // $10 default, NOT i64::default() = 0
 
             max_positions: std::env::var("GATE_MAX_POSITIONS")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(3),
+                .unwrap_or(defaults.max_positions),
 
             ping_threshold_ms: std::env::var("GATE_PING_THRESHOLD_MS")
                 .ok()
                 .and_then(|v| v.parse().ok())
-                .unwrap_or(100),
+                .unwrap_or(defaults.ping_threshold_ms),
         }
     }
 }
@@ -85,16 +86,24 @@ impl RiskViolations {
 }
 
 /// Central risk manager — shared across engine, strategy, and gateway.
-/// Thread-safe: uses atomics +RwLock for counters.
+///
+/// # Memory ordering
+/// - `kill_switch`: Release on write, Acquire on read — ensures activation is
+///   visible across threads on non-TSO architectures (ARM/Graviton).
+/// - `position_count`, `last_ping_ms`, `paper_mode`: Relaxed — these are
+///   sampled values where stale reads are acceptable for one tick.
+///
+/// # P&L snapshot atomicity
+/// `peak_pnl` and `cumulative_pnl` are merged into a single `RwLock<(i64, i64)>`
+/// so `current_drawdown_raw()` reads both values under one lock, avoiding TOCTOU.
 pub struct RiskManager {
     /// Kill switch — if set, no new positions can be opened.
+    /// Release/Acquire ordering: must be visible cross-thread immediately.
     kill_switch: AtomicBool,
     /// Current number of open positions.
     position_count: AtomicU64,
-    /// Peak cumulative P&L (high-water mark in raw units).
-    peak_pnl: RwLock<i64>,
-    /// Current cumulative P&L from strategy.
-    cumulative_pnl: RwLock<i64>,
+    /// (peak_pnl, cumulative_pnl) — single lock for atomic snapshot.
+    pnl: RwLock<(i64, i64)>,
     /// Most recent WS ping latency in ms.
     last_ping_ms: AtomicU64,
     /// Config snapshot.
@@ -120,8 +129,7 @@ impl RiskManager {
         Self {
             kill_switch: AtomicBool::new(false),
             position_count: AtomicU64::new(0),
-            peak_pnl: RwLock::new(0),
-            cumulative_pnl: RwLock::new(0),
+            pnl: RwLock::new((0, 0)), // (peak, cumulative)
             last_ping_ms: AtomicU64::new(0),
             config,
             paper_mode: AtomicBool::new(true),
@@ -137,21 +145,19 @@ impl RiskManager {
     /// Update the current cumulative P&L and peak tracker.
     /// Called after each trade closes.
     pub fn update_pnl(&self, realized_pnl: i64) {
-        let mut current = self.cumulative_pnl.write();
+        let mut guard = self.pnl.write();
+        let (peak, current) = &mut *guard;
         *current += realized_pnl;
-        let pnl = *current;
-
-        let mut peak = self.peak_pnl.write();
-        if pnl > *peak {
-            *peak = pnl;
+        if *current > *peak {
+            *peak = *current;
         }
     }
 
     /// Full P&L sync — called periodically or on state recovery to reconcile peak tracking.
     pub fn sync_cumulative_pnl(&self, pnl: i64) {
-        let mut current = self.cumulative_pnl.write();
+        let mut guard = self.pnl.write();
+        let (peak, current) = &mut *guard;
         *current = pnl;
-        let mut peak = self.peak_pnl.write();
         if pnl > *peak {
             *peak = pnl;
         }
@@ -164,10 +170,22 @@ impl RiskManager {
     }
 
     /// Record that a position was closed.
+    ///
+    /// Guards against wrapping to u64::MAX when count is already 0
+    /// (defensive — should not happen if open/close calls are balanced).
     pub fn position_closed(&self) {
-        let prev = self.position_count.fetch_sub(1, Ordering::Relaxed);
-        if prev > 0 {
-            info!("risk: position closed (count={})", prev - 1);
+        let prev = self
+            .position_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |v| {
+                if v > 0 {
+                    Some(v - 1)
+                } else {
+                    None
+                }
+            });
+        match prev {
+            Ok(old) => info!("risk: position closed (count={})", old - 1),
+            Err(_) => warn!("risk: position_closed() called with count=0 (bug: unbalanced calls)"),
         }
     }
 
@@ -178,34 +196,39 @@ impl RiskManager {
 
     /// Activate the kill switch — stops all new position entries immediately.
     /// Returns the previous state.
+    ///
+    /// Uses Release ordering so the write is visible to all reader threads
+    /// even on non-TSO architectures (ARM, Graviton).
     pub fn activate_kill_switch(&self) -> bool {
-        let prev = self.kill_switch.swap(true, Ordering::Relaxed);
+        let prev = self.kill_switch.swap(true, Ordering::Release);
         warn!("risk: KILL SWITCH ACTIVATED (was={})", prev);
         prev
     }
 
     /// Deactivate the kill switch (manual reset required).
     pub fn deactivate_kill_switch(&self) {
-        self.kill_switch.store(false, Ordering::Relaxed);
+        self.kill_switch.store(false, Ordering::Release);
         info!("risk: kill switch deactivated");
     }
 
     /// Returns true if the kill switch is currently active.
     pub fn is_kill_switch_active(&self) -> bool {
-        self.kill_switch.load(Ordering::Relaxed)
+        self.kill_switch.load(Ordering::Acquire)
     }
 
     /// Returns the current drawdown in raw units (positive = loss from peak).
+    ///
+    /// Reads both peak and cumulative under a single RwLock — atomic snapshot,
+    /// no TOCTOU between the two values.
     pub fn current_drawdown_raw(&self) -> i64 {
-        let peak = *self.peak_pnl.read();
-        let current = *self.cumulative_pnl.read();
+        let (peak, current) = *self.pnl.read();
         (peak - current).max(0)
     }
 
     /// Check all risk conditions and return violations.
     /// In paper mode, drawdown and position violations are logged but do not block.
     pub fn check(&self) -> RiskViolations {
-        let kill_switch_active = self.kill_switch.load(Ordering::Relaxed);
+        let kill_switch_active = self.kill_switch.load(Ordering::Acquire);
         let high_latency =
             self.last_ping_ms.load(Ordering::Relaxed) > self.config.ping_threshold_ms;
         let positions = self.position_count.load(Ordering::Relaxed) as usize;
@@ -256,15 +279,16 @@ impl RiskManager {
 
     /// Human-readable risk status for health endpoint / logs.
     pub fn status(&self) -> RiskStatus {
+        let (peak_pnl, cumulative_pnl) = *self.pnl.read();
         RiskStatus {
-            kill_switch: self.kill_switch.load(Ordering::Relaxed),
+            kill_switch: self.kill_switch.load(Ordering::Acquire),
             position_count: self.position_count.load(Ordering::Relaxed) as usize,
             max_positions: self.config.max_positions,
-            drawdown_raw: self.current_drawdown_raw(),
+            drawdown_raw: (peak_pnl - cumulative_pnl).max(0),
             max_drawdown_raw: self.config.max_drawdown_raw,
             last_ping_ms: self.last_ping_ms.load(Ordering::Relaxed),
             ping_threshold_ms: self.config.ping_threshold_ms,
-            cumulative_pnl: *self.cumulative_pnl.read(),
+            cumulative_pnl,
         }
     }
 }

--- a/crates/risk/src/lib.rs
+++ b/crates/risk/src/lib.rs
@@ -1,0 +1,282 @@
+//! risk — position safety, drawdown limits, kill switch, and WS latency monitoring.
+//!
+//! Thread 2 (warm): risk checks before every new position.
+//!
+//! Paper-trading aware: kill switch and latency monitoring are always active;
+//! drawdown/position limits are advisory in paper mode (log-only).
+
+use parking_lot::RwLock;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use tracing::{info, warn};
+
+/// Risk configuration — read from environment variables.
+#[derive(Debug, Clone)]
+pub struct RiskConfig {
+    /// Max drawdown in USD (raw units, 1e8 = $1). Default: 10 USD = 1_000_000_000.
+    pub max_drawdown_raw: i64,
+    /// Max simultaneous positions. Default: 3.
+    pub max_positions: usize,
+    /// WS ping latency threshold in ms. Default: 100.
+    pub ping_threshold_ms: u64,
+}
+
+impl Default for RiskConfig {
+    fn default() -> Self {
+        Self {
+            max_drawdown_raw: 10_000_000_000, // $10 in 1e8 units
+            max_positions: 3,
+            ping_threshold_ms: 100,
+        }
+    }
+}
+
+impl RiskConfig {
+    pub fn from_env() -> Self {
+        Self {
+            max_drawdown_raw: std::env::var("GATE_MAX_DRAWDOWN_USD")
+                .ok()
+                .and_then(|v| v.parse::<f64>().ok())
+                .map(|v| (v * 1e8_f64) as i64)
+                .unwrap_or_default(),
+
+            max_positions: std::env::var("GATE_MAX_POSITIONS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(3),
+
+            ping_threshold_ms: std::env::var("GATE_PING_THRESHOLD_MS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(100),
+        }
+    }
+}
+
+/// Result of a risk check — always checks all conditions and returns ALL violations.
+#[derive(Debug, Default)]
+pub struct RiskViolations {
+    pub drawdown_exceeded: bool,
+    pub max_positions_exceeded: bool,
+    pub high_latency: bool,
+    pub kill_switch_active: bool,
+}
+
+impl RiskViolations {
+    pub fn is_ok(&self) -> bool {
+        !self.drawdown_exceeded
+            && !self.max_positions_exceeded
+            && !self.high_latency
+            && !self.kill_switch_active
+    }
+
+    pub fn reason(&self) -> Option<&'static str> {
+        if self.kill_switch_active {
+            Some("kill_switch")
+        } else if self.high_latency {
+            Some("high_latency")
+        } else if self.max_positions_exceeded {
+            Some("max_positions")
+        } else if self.drawdown_exceeded {
+            Some("drawdown_exceeded")
+        } else {
+            None
+        }
+    }
+}
+
+/// Central risk manager — shared across engine, strategy, and gateway.
+/// Thread-safe: uses atomics +RwLock for counters.
+pub struct RiskManager {
+    /// Kill switch — if set, no new positions can be opened.
+    kill_switch: AtomicBool,
+    /// Current number of open positions.
+    position_count: AtomicU64,
+    /// Peak cumulative P&L (high-water mark in raw units).
+    peak_pnl: RwLock<i64>,
+    /// Current cumulative P&L from strategy.
+    cumulative_pnl: RwLock<i64>,
+    /// Most recent WS ping latency in ms.
+    last_ping_ms: AtomicU64,
+    /// Config snapshot.
+    config: RiskConfig,
+    /// True if paper trading mode.
+    paper_mode: AtomicBool,
+}
+
+impl Default for RiskManager {
+    fn default() -> Self {
+        Self::new(RiskConfig::default())
+    }
+}
+
+impl RiskManager {
+    pub fn new(config: RiskConfig) -> Self {
+        info!(
+            "risk: max_drawdown=${:.2} max_positions={} ping_threshold={}ms",
+            config.max_drawdown_raw as f64 / 1e8,
+            config.max_positions,
+            config.ping_threshold_ms,
+        );
+        Self {
+            kill_switch: AtomicBool::new(false),
+            position_count: AtomicU64::new(0),
+            peak_pnl: RwLock::new(0),
+            cumulative_pnl: RwLock::new(0),
+            last_ping_ms: AtomicU64::new(0),
+            config,
+            paper_mode: AtomicBool::new(true),
+        }
+    }
+
+    /// Set paper mode. In paper mode, drawdown/position violations are logged but do not block.
+    pub fn set_paper_mode(&self, paper: bool) {
+        self.paper_mode.store(paper, Ordering::Relaxed);
+        info!("risk: paper_mode={}", paper);
+    }
+
+    /// Update the current cumulative P&L and peak tracker.
+    /// Called after each trade closes.
+    pub fn update_pnl(&self, realized_pnl: i64) {
+        let mut current = self.cumulative_pnl.write();
+        *current += realized_pnl;
+        let pnl = *current;
+
+        let mut peak = self.peak_pnl.write();
+        if pnl > *peak {
+            *peak = pnl;
+        }
+    }
+
+    /// Full P&L sync — called periodically or on state recovery to reconcile peak tracking.
+    pub fn sync_cumulative_pnl(&self, pnl: i64) {
+        let mut current = self.cumulative_pnl.write();
+        *current = pnl;
+        let mut peak = self.peak_pnl.write();
+        if pnl > *peak {
+            *peak = pnl;
+        }
+    }
+
+    /// Record that a new position was opened.
+    pub fn position_opened(&self) {
+        let prev = self.position_count.fetch_add(1, Ordering::Relaxed);
+        info!("risk: position opened (count={})", prev + 1);
+    }
+
+    /// Record that a position was closed.
+    pub fn position_closed(&self) {
+        let prev = self.position_count.fetch_sub(1, Ordering::Relaxed);
+        if prev > 0 {
+            info!("risk: position closed (count={})", prev - 1);
+        }
+    }
+
+    /// Update the latest observed WS ping latency in ms.
+    pub fn update_ping_latency(&self, latency_ms: u64) {
+        self.last_ping_ms.store(latency_ms, Ordering::Relaxed);
+    }
+
+    /// Activate the kill switch — stops all new position entries immediately.
+    /// Returns the previous state.
+    pub fn activate_kill_switch(&self) -> bool {
+        let prev = self.kill_switch.swap(true, Ordering::Relaxed);
+        warn!("risk: KILL SWITCH ACTIVATED (was={})", prev);
+        prev
+    }
+
+    /// Deactivate the kill switch (manual reset required).
+    pub fn deactivate_kill_switch(&self) {
+        self.kill_switch.store(false, Ordering::Relaxed);
+        info!("risk: kill switch deactivated");
+    }
+
+    /// Returns true if the kill switch is currently active.
+    pub fn is_kill_switch_active(&self) -> bool {
+        self.kill_switch.load(Ordering::Relaxed)
+    }
+
+    /// Returns the current drawdown in raw units (positive = loss from peak).
+    pub fn current_drawdown_raw(&self) -> i64 {
+        let peak = *self.peak_pnl.read();
+        let current = *self.cumulative_pnl.read();
+        (peak - current).max(0)
+    }
+
+    /// Check all risk conditions and return violations.
+    /// In paper mode, drawdown and position violations are logged but do not block.
+    pub fn check(&self) -> RiskViolations {
+        let kill_switch_active = self.kill_switch.load(Ordering::Relaxed);
+        let high_latency =
+            self.last_ping_ms.load(Ordering::Relaxed) > self.config.ping_threshold_ms;
+        let positions = self.position_count.load(Ordering::Relaxed) as usize;
+        let max_positions_exceeded = positions >= self.config.max_positions;
+
+        let drawdown_exceeded = self.current_drawdown_raw() > self.config.max_drawdown_raw;
+
+        let v = RiskViolations {
+            drawdown_exceeded,
+            max_positions_exceeded,
+            high_latency,
+            kill_switch_active,
+        };
+
+        if !v.is_ok() {
+            let reason = v.reason().unwrap_or("unknown");
+            if self.paper_mode.load(Ordering::Relaxed) && !kill_switch_active && !high_latency {
+                // In paper mode, log but don't block on drawdown/position limits
+                warn!("risk: violation detected (paper-mode log-only): {}", reason);
+            } else {
+                warn!("risk: VIOLATION — blocked: {}", reason);
+            }
+        }
+
+        v
+    }
+
+    /// Returns true if a new position can be opened given current risk state.
+    ///
+    /// Hard blocks (always enforced, even in paper mode):
+    /// - Kill switch active
+    /// - WS ping latency > threshold
+    ///
+    /// Advisory only in paper mode (logged but not enforced):
+    /// - Max drawdown exceeded
+    /// - Max position count exceeded
+    pub fn can_open_position(&self) -> bool {
+        let v = self.check();
+        if v.kill_switch_active || v.high_latency {
+            return false;
+        }
+        if self.paper_mode.load(Ordering::Relaxed) {
+            // Drawdown + position limits are advisory in paper mode
+            return true;
+        }
+        v.is_ok()
+    }
+
+    /// Human-readable risk status for health endpoint / logs.
+    pub fn status(&self) -> RiskStatus {
+        RiskStatus {
+            kill_switch: self.kill_switch.load(Ordering::Relaxed),
+            position_count: self.position_count.load(Ordering::Relaxed) as usize,
+            max_positions: self.config.max_positions,
+            drawdown_raw: self.current_drawdown_raw(),
+            max_drawdown_raw: self.config.max_drawdown_raw,
+            last_ping_ms: self.last_ping_ms.load(Ordering::Relaxed),
+            ping_threshold_ms: self.config.ping_threshold_ms,
+            cumulative_pnl: *self.cumulative_pnl.read(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct RiskStatus {
+    pub kill_switch: bool,
+    pub position_count: usize,
+    pub max_positions: usize,
+    pub drawdown_raw: i64,
+    pub max_drawdown_raw: i64,
+    pub last_ping_ms: u64,
+    pub ping_threshold_ms: u64,
+    pub cumulative_pnl: i64,
+}

--- a/crates/risk/tests/risk_test.rs
+++ b/crates/risk/tests/risk_test.rs
@@ -1,0 +1,117 @@
+use risk::{RiskConfig, RiskManager};
+
+fn make_risk(max_drawdown_usd: f64, max_positions: usize, ping_ms: u64) -> RiskManager {
+    RiskManager::new(RiskConfig {
+        max_drawdown_raw: (max_drawdown_usd * 1e8) as i64,
+        max_positions,
+        ping_threshold_ms: ping_ms,
+    })
+}
+
+#[test]
+fn kill_switch_blocks_in_live_mode() {
+    let rm = make_risk(100.0, 5, 200);
+    rm.set_paper_mode(false);
+    assert!(rm.can_open_position());
+    rm.activate_kill_switch();
+    assert!(!rm.can_open_position());
+    rm.deactivate_kill_switch();
+    assert!(rm.can_open_position());
+}
+
+#[test]
+fn kill_switch_blocks_in_paper_mode_too() {
+    // Kill switch is always hard — even paper mode.
+    let rm = make_risk(100.0, 5, 200);
+    rm.set_paper_mode(true);
+    rm.activate_kill_switch();
+    assert!(!rm.can_open_position());
+}
+
+#[test]
+fn max_positions_blocks_in_live_mode() {
+    let rm = make_risk(100.0, 2, 200);
+    rm.set_paper_mode(false);
+    rm.position_opened();
+    assert!(rm.can_open_position()); // 1 of 2
+    rm.position_opened();
+    assert!(!rm.can_open_position()); // 2 of 2 → at limit
+}
+
+#[test]
+fn max_positions_advisory_in_paper_mode() {
+    let rm = make_risk(100.0, 1, 200);
+    rm.set_paper_mode(true);
+    rm.position_opened();
+    rm.position_opened();
+    // Paper mode: position count violations are advisory only
+    assert!(rm.can_open_position());
+}
+
+#[test]
+fn drawdown_blocks_in_live_mode() {
+    let rm = make_risk(10.0, 5, 200);
+    rm.set_paper_mode(false);
+    // Gain to set peak, then drop below
+    rm.update_pnl(20_000_000_000); // +$200 peak
+    rm.update_pnl(-21_000_000_000); // now at -$10 from peak
+    assert!(!rm.can_open_position()); // drawdown > $10 limit
+}
+
+#[test]
+fn high_latency_blocks_in_both_modes() {
+    for paper in [true, false] {
+        let rm = make_risk(100.0, 5, 100);
+        rm.set_paper_mode(paper);
+        rm.update_ping_latency(101); // 1ms over threshold
+        assert!(
+            !rm.can_open_position(),
+            "paper={}: high latency should block",
+            paper
+        );
+    }
+}
+
+#[test]
+fn position_opened_and_closed_tracking() {
+    let rm = make_risk(100.0, 3, 200);
+    rm.set_paper_mode(false);
+    rm.position_opened();
+    rm.position_opened();
+    rm.position_closed();
+    let status = rm.status();
+    assert_eq!(status.position_count, 1);
+}
+
+#[test]
+fn drawdown_calculation() {
+    let rm = make_risk(100.0, 5, 200);
+    assert_eq!(rm.current_drawdown_raw(), 0);
+    rm.update_pnl(1_000_000_000); // +$10 peak
+    rm.update_pnl(-500_000_000); // now +$5 cumulative
+                                 // Peak = $10, current = $5, drawdown = $5
+    assert_eq!(rm.current_drawdown_raw(), 500_000_000);
+}
+
+#[test]
+fn risk_status_serializes() {
+    let rm = make_risk(100.0, 5, 200);
+    let status = rm.status();
+    let json = serde_json::to_string(&status).unwrap();
+    assert!(json.contains("kill_switch"));
+    assert!(json.contains("position_count"));
+    assert!(json.contains("drawdown_raw"));
+}
+
+#[test]
+fn risk_violations_reason_priority() {
+    // Kill switch takes highest priority
+    let rm = make_risk(1.0, 1, 50);
+    rm.set_paper_mode(false);
+    rm.activate_kill_switch();
+    rm.update_ping_latency(200);
+    rm.update_pnl(2_000_000_000);
+    rm.update_pnl(-3_000_000_000);
+    let v = rm.check();
+    assert_eq!(v.reason(), Some("kill_switch"));
+}

--- a/crates/risk/tests/risk_test.rs
+++ b/crates/risk/tests/risk_test.rs
@@ -1,4 +1,5 @@
 use risk::{RiskConfig, RiskManager};
+use std::env;
 
 fn make_risk(max_drawdown_usd: f64, max_positions: usize, ping_ms: u64) -> RiskManager {
     RiskManager::new(RiskConfig {
@@ -101,6 +102,72 @@ fn risk_status_serializes() {
     assert!(json.contains("kill_switch"));
     assert!(json.contains("position_count"));
     assert!(json.contains("drawdown_raw"));
+}
+
+// ── from_env() regression tests ─────────────────────────────────────────────
+
+#[test]
+fn from_env_default_max_drawdown_is_ten_dollars() {
+    // CRITICAL regression: .unwrap_or_default() = 0, not $10.
+    // Must use .unwrap_or(defaults.max_drawdown_raw).
+    env::remove_var("GATE_MAX_DRAWDOWN_USD");
+    env::remove_var("GATE_MAX_POSITIONS");
+    env::remove_var("GATE_PING_THRESHOLD_MS");
+    let cfg = RiskConfig::from_env();
+    assert_eq!(
+        cfg.max_drawdown_raw,
+        10_000_000_000, // $10 in 1e8 units
+        "from_env() without GATE_MAX_DRAWDOWN_USD must default to $10, not $0"
+    );
+    assert_eq!(cfg.max_positions, 3);
+    assert_eq!(cfg.ping_threshold_ms, 100);
+}
+
+#[test]
+fn from_env_respects_explicit_value() {
+    env::set_var("GATE_MAX_DRAWDOWN_USD", "25.5");
+    env::set_var("GATE_MAX_POSITIONS", "7");
+    env::set_var("GATE_PING_THRESHOLD_MS", "50");
+    let cfg = RiskConfig::from_env();
+    // Clean up before assert so test isolation is preserved on failure
+    env::remove_var("GATE_MAX_DRAWDOWN_USD");
+    env::remove_var("GATE_MAX_POSITIONS");
+    env::remove_var("GATE_PING_THRESHOLD_MS");
+    assert_eq!(cfg.max_drawdown_raw, (25.5 * 1e8) as i64);
+    assert_eq!(cfg.max_positions, 7);
+    assert_eq!(cfg.ping_threshold_ms, 50);
+}
+
+// ── position_count wiring ────────────────────────────────────────────────────
+
+#[test]
+fn position_closed_saturates_at_zero() {
+    let rm = make_risk(100.0, 5, 200);
+    // Should not wrap to u64::MAX
+    rm.position_closed(); // count was 0 — saturate guard
+    let status = rm.status();
+    assert_eq!(
+        status.position_count, 0,
+        "position_closed() on 0 must not wrap"
+    );
+}
+
+#[test]
+fn position_count_accurate_through_open_close_cycle() {
+    let rm = make_risk(100.0, 3, 200);
+    rm.set_paper_mode(false);
+    rm.position_opened();
+    rm.position_opened();
+    assert_eq!(rm.status().position_count, 2);
+    rm.position_closed();
+    assert_eq!(rm.status().position_count, 1);
+    rm.position_closed();
+    assert_eq!(rm.status().position_count, 0);
+    // Check max_positions blocking at limit
+    rm.position_opened();
+    rm.position_opened();
+    rm.position_opened();
+    assert!(!rm.can_open_position(), "at max_positions=3 should block");
 }
 
 #[test]

--- a/crates/strategy/Cargo.toml
+++ b/crates/strategy/Cargo.toml
@@ -6,5 +6,6 @@ edition.workspace = true
 [dependencies]
 types = { path = "../types" }
 engine = { path = "../engine" }
+risk = { path = "../risk" }
 parking_lot = { workspace = true }
 tracing = { workspace = true }

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -15,6 +15,7 @@ pub use funding::FundingStrategy;
 
 use engine::Engine;
 use parking_lot::RwLock;
+use risk::RiskManager;
 use std::sync::Arc;
 use tracing::{info, warn};
 use types::{ArbitragePosition, Leg, LegKind, SpreadSignal, TradeState, SCALE};
@@ -51,6 +52,8 @@ pub struct Strategy {
     paper_stats: RwLock<PaperStats>,
     /// Tick counter for summary printing.
     tick_counter: RwLock<u64>,
+    /// Optional risk manager — checked before every entry.
+    risk: Option<Arc<RiskManager>>,
 }
 
 impl Strategy {
@@ -68,7 +71,13 @@ impl Strategy {
             cumulative_pnl: RwLock::new(0),
             paper_stats: RwLock::new(PaperStats::default()),
             tick_counter: RwLock::new(0),
+            risk: None,
         }
+    }
+
+    /// Attach a risk manager. Call before starting the tick loop.
+    pub fn set_risk(&mut self, risk: Arc<RiskManager>) {
+        self.risk = Some(risk);
     }
 
     /// Called every tick from the hot path — check spread, emit signals.
@@ -89,14 +98,28 @@ impl Strategy {
             }
 
             if self.position.read().is_none() {
-                info!(
-                    "SPREAD SIGNAL: raw={} pct={} bid={} ask={}",
-                    sig.spread_raw, sig.spread_pct, sig.bid_price, sig.ask_price
-                );
-                if self.paper_mode {
-                    self.paper_open_position(sig.clone());
+                // Risk gate: check before opening any position
+                let risk_ok = self
+                    .risk
+                    .as_ref()
+                    .map(|r| r.can_open_position())
+                    .unwrap_or(true);
+
+                if risk_ok {
+                    info!(
+                        "SPREAD SIGNAL: raw={} pct={} bid={} ask={}",
+                        sig.spread_raw, sig.spread_pct, sig.bid_price, sig.ask_price
+                    );
+                    if self.paper_mode {
+                        self.paper_open_position(sig.clone());
+                    } else {
+                        self.open_position(sig.clone());
+                    }
                 } else {
-                    self.open_position(sig.clone());
+                    warn!(
+                        "SPREAD SIGNAL skipped — risk gate blocked (raw={} pct={})",
+                        sig.spread_raw, sig.spread_pct
+                    );
                 }
             }
         }
@@ -239,6 +262,11 @@ impl Strategy {
             *cum_pnl += trade_pnl_raw;
             *cum_pnl
         };
+
+        // Sync risk manager with realised P&L (peak tracking, drawdown gate)
+        if let Some(ref risk) = self.risk {
+            risk.update_pnl(trade_pnl_raw);
+        }
 
         {
             let mut stats = self.paper_stats.write();

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -168,6 +168,10 @@ impl Strategy {
         pos.state = TradeState::BothFilled;
         *self.position.write() = Some(pos);
 
+        if let Some(ref risk) = self.risk {
+            risk.position_opened();
+        }
+
         info!(
             "PAPER OPEN: spot_buy@{} perp_short@{} spread_raw={} spread_pct={}",
             sig.bid_price, sig.ask_price, sig.spread_raw, sig.spread_pct
@@ -292,6 +296,10 @@ impl Strategy {
 
         pos.state = TradeState::Closed;
         *pos_guard = None;
+
+        if let Some(ref risk) = self.risk {
+            risk.position_closed();
+        }
     }
 
     fn open_position(&self, sig: SpreadSignal) {
@@ -318,6 +326,10 @@ impl Strategy {
         };
 
         *self.position.write() = Some(ArbitragePosition::new(leg1, leg2, now));
+
+        if let Some(ref risk) = self.risk {
+            risk.position_opened();
+        }
     }
 
     fn check_timeouts(&self) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use tracing_subscriber::FmtSubscriber;
 use engine::Engine;
 use frontend_ws::FrontendWs;
 use gateway_ws::{parse_price as gw_parse_price, ReconnectConfig, WsEvent, CHANNEL_FUNDING_RATE};
+use risk::RiskManager;
 use strategy::{FundingStrategy, Strategy};
 use types::{Level as ObLevel, OrderBook};
 
@@ -145,6 +146,7 @@ async fn run_gateway_once(
     spot_symbol: &str,
     perp_symbol: &str,
     hot_path: Arc<HotPath>,
+    risk: Arc<RiskManager>,
 ) -> Result<()> {
     use tokio_tungstenite::connect_async;
 
@@ -184,10 +186,12 @@ async fn run_gateway_once(
     debug!("Subscribed to futures.funding_rate");
 
     let mut ping_interval = tokio::time::interval(Duration::from_secs(20));
+    let mut last_ping_sent: Option<Instant> = None;
 
     loop {
         tokio::select! {
             _ = ping_interval.tick() => {
+                last_ping_sent = Some(Instant::now());
                 write.send(Message::Ping(vec![].into())).await?;
                 debug!("Sent ping");
             }
@@ -195,6 +199,14 @@ async fn run_gateway_once(
                 match msg {
                     Some(Ok(Message::Text(text))) => {
                         hot_path.process_text(&text);
+                    }
+                    Some(Ok(Message::Pong(_))) => {
+                        // Measure round-trip and report to risk manager
+                        if let Some(sent) = last_ping_sent.take() {
+                            let rtt_ms = sent.elapsed().as_millis() as u64;
+                            risk.update_ping_latency(rtt_ms);
+                            debug!("Pong RTT: {}ms", rtt_ms);
+                        }
                     }
                     Some(Ok(Message::Ping(data))) => {
                         write.send(Message::Pong(data)).await?;
@@ -229,6 +241,7 @@ async fn run_gateway_with_reconnect(
     perp_symbol: &str,
     hot_path: Arc<HotPath>,
     health: Arc<health::HealthHandle>,
+    risk: Arc<RiskManager>,
     cfg: ReconnectConfig,
 ) -> Result<()> {
     // consecutive_failures counts uninterrupted failures (reset on clean connect).
@@ -261,7 +274,14 @@ async fn run_gateway_with_reconnect(
             tokio::time::sleep(delay).await;
         }
 
-        match run_gateway_once(spot_symbol, perp_symbol, Arc::clone(&hot_path)).await {
+        match run_gateway_once(
+            spot_symbol,
+            perp_symbol,
+            Arc::clone(&hot_path),
+            Arc::clone(&risk),
+        )
+        .await
+        {
             Ok(()) => {
                 // Clean close — not a failure. Reset consecutive failure counter and
                 // outage timer so the 10-strikes limit counts consecutive bad reconnects,
@@ -353,11 +373,24 @@ async fn main() -> anyhow::Result<()> {
     let engine = Arc::new(engine::Engine::<20, 20>::new());
     health.set_engine(health::EngineStatus::Idle).await;
 
-    // Spread arb strategy — threshold from config
-    let strategy = Arc::new(strategy::Strategy::new(
-        Arc::clone(&engine),
-        cfg.spread_threshold_raw,
-    ));
+    // Risk manager — drawdown limits, position cap, kill switch, latency gate
+    let risk_cfg = risk::RiskConfig::from_env();
+    let risk_manager = Arc::new(risk::RiskManager::new(risk_cfg));
+    risk_manager.set_paper_mode(cfg.paper_mode);
+    info!(
+        "Risk manager: paper_mode={} max_drawdown_raw={} max_positions={} ping_threshold={}ms",
+        cfg.paper_mode,
+        risk_manager.status().max_drawdown_raw,
+        risk_manager.status().max_positions,
+        risk_manager.status().ping_threshold_ms,
+    );
+
+    // Spread arb strategy — threshold from config, risk manager attached
+    let strategy = {
+        let mut s = strategy::Strategy::new(Arc::clone(&engine), cfg.spread_threshold_raw);
+        s.set_risk(Arc::clone(&risk_manager));
+        Arc::new(s)
+    };
 
     // Funding arb strategy
     let funding_strategy = Arc::new(FundingStrategy::new(cfg.paper_mode));
@@ -423,6 +456,7 @@ async fn main() -> anyhow::Result<()> {
         &cfg.perp_symbol,
         hot_path,
         Arc::clone(&health),
+        Arc::clone(&risk_manager),
         ReconnectConfig::default(),
     )
     .await;


### PR DESCRIPTION
## Changes (closes #5)

### New crate: crates/risk

**RiskConfig** (from env vars):
- `GATE_MAX_DRAWDOWN_USD` → `max_drawdown_raw` (default $10)
- `GATE_MAX_POSITIONS` → `max_positions` (default 3)
- `GATE_PING_THRESHOLD_MS` → `ping_threshold_ms` (default 100ms)

**RiskManager**:
- Kill switch: `AtomicBool` — `activate_kill_switch()` / `deactivate_kill_switch()`
- Position count: `AtomicU64` — `position_opened()` / `position_closed()`
- P&L tracking: `update_pnl()` / `sync_cumulative_pnl()` + peak high-water mark for drawdown calculation
- Ping latency: `update_ping_latency(rtt_ms)` from WS pong RTT

**Violation semantics** (important distinction from old code):
- **Hard blocks (always enforced, paper and live)**: kill switch, WS latency > threshold
- **Advisory in paper mode (logged only)**: drawdown exceeded, max_positions exceeded
- Old code returned  unconditionally in paper mode — kill switch and high latency did NOT block. Fixed.

**RiskStatus**: `serde::Serialize` — ready for health endpoint integration.

### Strategy wiring (crates/strategy/src/lib.rs)
- `set_risk(Arc<RiskManager>)`: optional injection before tick loop
- `on_tick_with_signal()`: risk gate checked before opening any position
- `paper_close_if_needed()`: calls `risk.update_pnl(trade_pnl_raw)` on close → peak/drawdown tracking updates

### main.rs
- `RiskManager::new(RiskConfig::from_env())` at startup, logs config
- `strategy.set_risk()` called before Arc wrapping
- `run_gateway_once()`: pong RTT → `risk.update_ping_latency()` (was missing)
- `run_gateway_with_reconnect()`: `Arc<RiskManager>` threaded through

### Tests (10 new — crates/risk/tests/risk_test.rs)
- Kill switch: blocks in both paper and live
- Max positions: blocks in live, advisory in paper
- Drawdown: blocks in live after peak-then-drop
- High latency: blocks in both modes
- Position count tracking (opened + closed)
- Drawdown arithmetic
- RiskStatus JSON serialization
- Violation reason priority (kill_switch > high_latency > max_positions > drawdown)