### PR TITLE
feat(#11): SQLite trade logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,18 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -80,6 +92,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
+name = "db"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -110,6 +135,18 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "find-msvc-tools"
@@ -244,6 +281,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "health"
 version = "0.1.0"
 dependencies = [
@@ -302,6 +357,17 @@ name = "libc"
 version = "0.2.183"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "lock_api"
@@ -406,6 +472,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -505,6 +577,20 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b838eba278d213a8beaf485bd313fd580ca4505a00d5871caeb1457c55322cae"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
 ]
 
 [[package]]
@@ -662,6 +748,7 @@ dependencies = [
 name = "strategy"
 version = "0.1.0"
 dependencies = [
+ "db",
  "engine",
  "parking_lot",
  "tracing",
@@ -884,6 +971,12 @@ name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 resolver = "2"
-members = ["crates/types", "crates/gateway-ws", "crates/engine", "crates/strategy", "crates/frontend-ws", "crates/order-manager", "crates/health"]
+members = ["crates/types", "crates/gateway-ws", "crates/engine", "crates/strategy", "crates/frontend-ws", "crates/order-manager", "crates/health", "crates/db"]
 
 [package]
 name = "gate-arb"

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "db"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+rusqlite = { version = "0.31", features = ["bundled"] }
+tokio = { version = "1.44", features = ["full"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+tracing = "0.1"
+thiserror = "2.0"
+anyhow = "1.0"

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -137,10 +137,14 @@ impl DbWriter {
         }
     }
 
-    /// Signal the background task to flush and exit.
-    /// After calling this, further writes are dropped.
-    pub fn shutdown(&self) {
-        let _ = self.tx.try_send(DbCmd::Shutdown);
+    /// Signal the background task to flush and exit, then await its completion.
+    ///
+    /// Uses an async send (`.send().await`) instead of `try_send` so the Shutdown
+    /// sentinel is **guaranteed** to be delivered even when the channel is at
+    /// capacity (e.g. during a spread burst). Callers must `.await` this.
+    pub async fn shutdown(self) {
+        // Ignore send error — task already exited (all DbWriter clones dropped).
+        let _ = self.tx.send(DbCmd::Shutdown).await;
     }
 }
 
@@ -236,7 +240,9 @@ pub struct DbReader {
 impl DbReader {
     pub fn open<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
         let conn = Connection::open(path)?;
-        conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA query_only = ON;")?;
+        // query_only = ON is sufficient for a read-only handle.
+        // PRAGMA journal_mode is omitted — it would silently fail under query_only anyway.
+        conn.execute_batch("PRAGMA query_only = ON;")?;
         Ok(Self { conn })
     }
 

--- a/crates/db/src/lib.rs
+++ b/crates/db/src/lib.rs
@@ -1,0 +1,320 @@
+//! db — structured trade logging to SQLite.
+//!
+//! Provides a non-blocking async writer (mpsc channel → background task)
+//! for use from the hot/warm strategy path.
+//!
+//! Schema:
+//! - `trades`: one row per closed arbitrage position
+//! - `spreads`: time-series spread snapshots (sampled, not every tick)
+//!
+//! Env vars:
+//! - `DB_PATH` — path to SQLite file (default: `gate-arb.db`)
+
+use rusqlite::{params, Connection};
+use std::path::{Path, PathBuf};
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// A closed arbitrage trade record.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct TradeRecord {
+    /// Unix microseconds when position was opened.
+    pub opened_at_us: u64,
+    /// Unix microseconds when position was closed.
+    pub closed_at_us: u64,
+    /// Entry spot bid price in raw units (1e8 = 1 USDT).
+    pub entry_price_raw: i64,
+    /// Exit price in raw units.
+    pub exit_price_raw: i64,
+    /// Position size in raw units (1e8 = 1 unit).
+    pub size_raw: i64,
+    /// Realized P&L in raw units (positive = profit).
+    pub pnl_raw: i64,
+    /// P&L as percentage of position value × 1e6 (i.e. 1% = 1_000_000).
+    pub pnl_pct_raw: i64,
+    /// Human-readable close reason (e.g. "exit_spread", "timeout", "emergency").
+    pub exit_reason: String,
+    /// True if paper trade (not executed on exchange).
+    pub paper: bool,
+}
+
+/// A spread snapshot for time-series analysis.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct SpreadSnapshot {
+    /// Unix microseconds.
+    pub ts_us: u64,
+    /// Spread in raw units (positive = spot cheaper than perp).
+    pub spread_raw: i64,
+    /// True if inverted direction (perp cheaper).
+    pub inverted: bool,
+    /// Spot bid price (raw).
+    pub spot_price_raw: i64,
+    /// Perp ask price (raw).
+    pub perp_price_raw: i64,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Writer command enum
+// ──────────────────────────────────────────────────────────────────────────────
+
+enum DbCmd {
+    Trade(TradeRecord),
+    Spread(SpreadSnapshot),
+    Shutdown,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// DbWriter — non-blocking handle
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Non-blocking handle to the DB writer background task.
+///
+/// Clone freely — all clones share the same sender channel.
+/// Drop all clones to trigger graceful shutdown (channel closes → background task exits).
+#[derive(Clone, Debug)]
+pub struct DbWriter {
+    tx: mpsc::Sender<DbCmd>,
+}
+
+impl DbWriter {
+    /// Open (or create) the SQLite database at `path` and spawn a background writer task.
+    ///
+    /// Returns `(DbWriter, join_handle)`. Keep the handle if you want to await shutdown.
+    pub fn open<P: AsRef<Path>>(path: P) -> anyhow::Result<(Self, tokio::task::JoinHandle<()>)> {
+        let path: PathBuf = path.as_ref().to_path_buf();
+        let conn = open_db(&path)?;
+        let (tx, mut rx) = mpsc::channel::<DbCmd>(1024);
+
+        let handle = tokio::spawn(async move {
+            info!("db: writer task started ({})", path.display());
+            while let Some(cmd) = rx.recv().await {
+                match cmd {
+                    DbCmd::Trade(r) => {
+                        if let Err(e) = insert_trade(&conn, &r) {
+                            error!("db: failed to insert trade: {}", e);
+                        }
+                    }
+                    DbCmd::Spread(s) => {
+                        if let Err(e) = insert_spread(&conn, &s) {
+                            error!("db: failed to insert spread: {}", e);
+                        }
+                    }
+                    DbCmd::Shutdown => {
+                        info!("db: writer task shutting down");
+                        break;
+                    }
+                }
+            }
+            info!("db: writer task exited");
+        });
+
+        Ok((Self { tx }, handle))
+    }
+
+    /// Open using `DB_PATH` env var, or `gate-arb.db` as default.
+    pub fn from_env() -> anyhow::Result<(Self, tokio::task::JoinHandle<()>)> {
+        let path = std::env::var("DB_PATH").unwrap_or_else(|_| "gate-arb.db".to_string());
+        info!("db: using path={}", path);
+        Self::open(path)
+    }
+
+    /// Record a closed trade (non-blocking, best-effort).
+    /// Drops silently if the channel is full (hot-path safe).
+    pub fn write_trade(&self, record: TradeRecord) {
+        if self.tx.try_send(DbCmd::Trade(record)).is_err() {
+            warn!("db: trade write dropped (channel full or closed)");
+        }
+    }
+
+    /// Record a spread snapshot (non-blocking, best-effort).
+    pub fn write_spread(&self, snapshot: SpreadSnapshot) {
+        if self.tx.try_send(DbCmd::Spread(snapshot)).is_err() {
+            warn!("db: spread write dropped (channel full or closed)");
+        }
+    }
+
+    /// Signal the background task to flush and exit.
+    /// After calling this, further writes are dropped.
+    pub fn shutdown(&self) {
+        let _ = self.tx.try_send(DbCmd::Shutdown);
+    }
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Internal DB helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+fn open_db(path: &Path) -> anyhow::Result<Connection> {
+    let conn = Connection::open(path)?;
+
+    // WAL mode for concurrent reads; foreign keys on.
+    conn.execute_batch(
+        "PRAGMA journal_mode = WAL;
+         PRAGMA synchronous = NORMAL;
+         PRAGMA foreign_keys = ON;",
+    )?;
+
+    conn.execute_batch(
+        "CREATE TABLE IF NOT EXISTS trades (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            opened_at_us    INTEGER NOT NULL,
+            closed_at_us    INTEGER NOT NULL,
+            entry_price_raw INTEGER NOT NULL,
+            exit_price_raw  INTEGER NOT NULL,
+            size_raw        INTEGER NOT NULL,
+            pnl_raw         INTEGER NOT NULL,
+            pnl_pct_raw     INTEGER NOT NULL,
+            exit_reason     TEXT NOT NULL,
+            paper           INTEGER NOT NULL DEFAULT 1
+        );
+        CREATE INDEX IF NOT EXISTS idx_trades_opened ON trades(opened_at_us);
+
+        CREATE TABLE IF NOT EXISTS spreads (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts_us           INTEGER NOT NULL,
+            spread_raw      INTEGER NOT NULL,
+            inverted        INTEGER NOT NULL DEFAULT 0,
+            spot_price_raw  INTEGER NOT NULL,
+            perp_price_raw  INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS idx_spreads_ts ON spreads(ts_us);",
+    )?;
+
+    info!("db: schema ready ({})", path.display());
+    Ok(conn)
+}
+
+fn insert_trade(conn: &Connection, r: &TradeRecord) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO trades
+         (opened_at_us, closed_at_us, entry_price_raw, exit_price_raw,
+          size_raw, pnl_raw, pnl_pct_raw, exit_reason, paper)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
+        params![
+            r.opened_at_us as i64,
+            r.closed_at_us as i64,
+            r.entry_price_raw,
+            r.exit_price_raw,
+            r.size_raw,
+            r.pnl_raw,
+            r.pnl_pct_raw,
+            r.exit_reason,
+            r.paper as i64,
+        ],
+    )?;
+    Ok(())
+}
+
+fn insert_spread(conn: &Connection, s: &SpreadSnapshot) -> rusqlite::Result<()> {
+    conn.execute(
+        "INSERT INTO spreads (ts_us, spread_raw, inverted, spot_price_raw, perp_price_raw)
+         VALUES (?1, ?2, ?3, ?4, ?5)",
+        params![
+            s.ts_us as i64,
+            s.spread_raw,
+            s.inverted as i64,
+            s.spot_price_raw,
+            s.perp_price_raw,
+        ],
+    )?;
+    Ok(())
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Read helpers (for health/API endpoints)
+// ──────────────────────────────────────────────────────────────────────────────
+
+/// Read-only connection for query endpoints.
+pub struct DbReader {
+    conn: Connection,
+}
+
+impl DbReader {
+    pub fn open<P: AsRef<Path>>(path: P) -> anyhow::Result<Self> {
+        let conn = Connection::open(path)?;
+        conn.execute_batch("PRAGMA journal_mode = WAL; PRAGMA query_only = ON;")?;
+        Ok(Self { conn })
+    }
+
+    pub fn from_env() -> anyhow::Result<Self> {
+        let path = std::env::var("DB_PATH").unwrap_or_else(|_| "gate-arb.db".to_string());
+        Self::open(path)
+    }
+
+    /// Return the N most recent trades (newest first).
+    pub fn recent_trades(&self, limit: usize) -> anyhow::Result<Vec<TradeRecord>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT opened_at_us, closed_at_us, entry_price_raw, exit_price_raw,
+                    size_raw, pnl_raw, pnl_pct_raw, exit_reason, paper
+             FROM trades ORDER BY closed_at_us DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            Ok(TradeRecord {
+                opened_at_us: row.get::<_, i64>(0)? as u64,
+                closed_at_us: row.get::<_, i64>(1)? as u64,
+                entry_price_raw: row.get(2)?,
+                exit_price_raw: row.get(3)?,
+                size_raw: row.get(4)?,
+                pnl_raw: row.get(5)?,
+                pnl_pct_raw: row.get(6)?,
+                exit_reason: row.get(7)?,
+                paper: row.get::<_, i64>(8)? != 0,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+
+    /// P&L summary: total_trades, wins, total_pnl_raw.
+    pub fn pnl_summary(&self) -> anyhow::Result<PnlSummary> {
+        let row = self.conn.query_row(
+            "SELECT COUNT(*),
+                    COALESCE(SUM(CASE WHEN pnl_raw > 0 THEN 1 ELSE 0 END), 0),
+                    COALESCE(SUM(pnl_raw), 0)
+             FROM trades",
+            [],
+            |r| {
+                Ok((
+                    r.get::<_, i64>(0)?,
+                    r.get::<_, i64>(1)?,
+                    r.get::<_, i64>(2)?,
+                ))
+            },
+        )?;
+        Ok(PnlSummary {
+            total_trades: row.0 as u64,
+            wins: row.1 as u64,
+            total_pnl_raw: row.2,
+        })
+    }
+
+    /// Return the N most recent spread snapshots (newest first).
+    pub fn recent_spreads(&self, limit: usize) -> anyhow::Result<Vec<SpreadSnapshot>> {
+        let mut stmt = self.conn.prepare(
+            "SELECT ts_us, spread_raw, inverted, spot_price_raw, perp_price_raw
+             FROM spreads ORDER BY ts_us DESC LIMIT ?1",
+        )?;
+        let rows = stmt.query_map(params![limit as i64], |row| {
+            Ok(SpreadSnapshot {
+                ts_us: row.get::<_, i64>(0)? as u64,
+                spread_raw: row.get(1)?,
+                inverted: row.get::<_, i64>(2)? != 0,
+                spot_price_raw: row.get(3)?,
+                perp_price_raw: row.get(4)?,
+            })
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()
+            .map_err(Into::into)
+    }
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct PnlSummary {
+    pub total_trades: u64,
+    pub wins: u64,
+    pub total_pnl_raw: i64,
+}

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -19,9 +19,9 @@ fn sample_trade(pnl_raw: i64, paper: bool) -> TradeRecord {
     }
 }
 
-fn sample_spread(spread_raw: i64, inverted: bool) -> SpreadSnapshot {
+fn sample_spread(ts_us: u64, spread_raw: i64, inverted: bool) -> SpreadSnapshot {
     SpreadSnapshot {
-        ts_us: 1_500_000,
+        ts_us,
         spread_raw,
         inverted,
         spot_price_raw: 50_000_00_000_000,
@@ -48,8 +48,7 @@ async fn write_and_read_trade() {
 
     writer.write_trade(sample_trade(1_000_000, true));
     sleep(Duration::from_millis(50)).await;
-    writer.shutdown();
-    sleep(Duration::from_millis(50)).await;
+    writer.shutdown().await;
 
     let reader = DbReader::open(&path).expect("open reader");
     let trades = reader.recent_trades(10).expect("recent_trades");
@@ -65,17 +64,17 @@ async fn write_and_read_trade() {
 async fn write_and_read_spread() {
     let (writer, _handle, path) = temp_db().await;
 
-    writer.write_spread(sample_spread(5_000_000, false));
-    writer.write_spread(sample_spread(-2_000_000, true));
+    // Distinct ts_us values so ORDER BY ts_us DESC is deterministic (no ties).
+    writer.write_spread(sample_spread(1_500_000, 5_000_000, false));
+    writer.write_spread(sample_spread(1_500_001, -2_000_000, true));
     sleep(Duration::from_millis(50)).await;
-    writer.shutdown();
-    sleep(Duration::from_millis(50)).await;
+    writer.shutdown().await;
 
     let reader = DbReader::open(&path).expect("open reader");
     let spreads = reader.recent_spreads(10).expect("recent_spreads");
     assert_eq!(spreads.len(), 2);
-    // newest first
-    assert!(spreads[0].inverted); // -2_000_000 inserted second
+    // newest first: ts_us=1_500_001 (inverted=true) must come before ts_us=1_500_000
+    assert!(spreads[0].inverted);
 
     let _ = std::fs::remove_file(path);
 }
@@ -88,8 +87,7 @@ async fn pnl_summary_correct() {
     writer.write_trade(sample_trade(-500_000, true));
     writer.write_trade(sample_trade(1_000_000, false));
     sleep(Duration::from_millis(80)).await;
-    writer.shutdown();
-    sleep(Duration::from_millis(50)).await;
+    writer.shutdown().await;
 
     let reader = DbReader::open(&path).expect("open reader");
     let summary = reader.pnl_summary().expect("pnl_summary");
@@ -108,8 +106,7 @@ async fn recent_trades_limit() {
         writer.write_trade(sample_trade(i * 100_000, true));
     }
     sleep(Duration::from_millis(80)).await;
-    writer.shutdown();
-    sleep(Duration::from_millis(50)).await;
+    writer.shutdown().await;
 
     let reader = DbReader::open(&path).expect("open reader");
     let trades = reader.recent_trades(3).expect("recent_trades");
@@ -133,15 +130,13 @@ async fn schema_idempotent_reopen() {
         let (w, _h) = DbWriter::open(&path).expect("first open");
         w.write_trade(sample_trade(100, true));
         sleep(Duration::from_millis(30)).await;
-        w.shutdown();
-        sleep(Duration::from_millis(30)).await;
+        w.shutdown().await;
     }
     {
         let (w, _h) = DbWriter::open(&path).expect("second open");
         w.write_trade(sample_trade(200, false));
         sleep(Duration::from_millis(30)).await;
-        w.shutdown();
-        sleep(Duration::from_millis(30)).await;
+        w.shutdown().await;
     }
 
     let reader = DbReader::open(&path).expect("reader");
@@ -153,10 +148,9 @@ async fn schema_idempotent_reopen() {
 #[tokio::test]
 async fn write_spread_empty_db_returns_zero_pnl() {
     let (writer, _handle, path) = temp_db().await;
-    writer.write_spread(sample_spread(1_000, false));
+    writer.write_spread(sample_spread(1_500_000, 1_000, false));
     sleep(Duration::from_millis(50)).await;
-    writer.shutdown();
-    sleep(Duration::from_millis(30)).await;
+    writer.shutdown().await;
 
     let reader = DbReader::open(&path).expect("reader");
     let summary = reader.pnl_summary().expect("pnl");

--- a/crates/db/tests/db_test.rs
+++ b/crates/db/tests/db_test.rs
@@ -1,0 +1,167 @@
+//! Integration tests for crates/db.
+//! Uses tempfile for an in-process SQLite database — no real files left behind.
+
+use db::{DbReader, DbWriter, PnlSummary, SpreadSnapshot, TradeRecord};
+use std::time::Duration;
+use tokio::time::sleep;
+
+fn sample_trade(pnl_raw: i64, paper: bool) -> TradeRecord {
+    TradeRecord {
+        opened_at_us: 1_000_000,
+        closed_at_us: 2_000_000,
+        entry_price_raw: 50_000_00_000_000, // $50,000
+        exit_price_raw: 50_010_00_000_000,
+        size_raw: 100_000_000, // 1 unit
+        pnl_raw,
+        pnl_pct_raw: 20_000, // 0.02%
+        exit_reason: "exit_spread".to_string(),
+        paper,
+    }
+}
+
+fn sample_spread(spread_raw: i64, inverted: bool) -> SpreadSnapshot {
+    SpreadSnapshot {
+        ts_us: 1_500_000,
+        spread_raw,
+        inverted,
+        spot_price_raw: 50_000_00_000_000,
+        perp_price_raw: 50_010_00_000_000,
+    }
+}
+
+async fn temp_db() -> (DbWriter, tokio::task::JoinHandle<()>, String) {
+    // Use a temp path unique per test
+    let path = format!(
+        "/tmp/gate-arb-test-{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let (w, h) = DbWriter::open(&path).expect("open db");
+    (w, h, path)
+}
+
+#[tokio::test]
+async fn write_and_read_trade() {
+    let (writer, _handle, path) = temp_db().await;
+
+    writer.write_trade(sample_trade(1_000_000, true));
+    sleep(Duration::from_millis(50)).await;
+    writer.shutdown();
+    sleep(Duration::from_millis(50)).await;
+
+    let reader = DbReader::open(&path).expect("open reader");
+    let trades = reader.recent_trades(10).expect("recent_trades");
+    assert_eq!(trades.len(), 1, "expected 1 trade");
+    assert_eq!(trades[0].pnl_raw, 1_000_000);
+    assert!(trades[0].paper);
+    assert_eq!(trades[0].exit_reason, "exit_spread");
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn write_and_read_spread() {
+    let (writer, _handle, path) = temp_db().await;
+
+    writer.write_spread(sample_spread(5_000_000, false));
+    writer.write_spread(sample_spread(-2_000_000, true));
+    sleep(Duration::from_millis(50)).await;
+    writer.shutdown();
+    sleep(Duration::from_millis(50)).await;
+
+    let reader = DbReader::open(&path).expect("open reader");
+    let spreads = reader.recent_spreads(10).expect("recent_spreads");
+    assert_eq!(spreads.len(), 2);
+    // newest first
+    assert!(spreads[0].inverted); // -2_000_000 inserted second
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn pnl_summary_correct() {
+    let (writer, _handle, path) = temp_db().await;
+
+    writer.write_trade(sample_trade(2_000_000, true));
+    writer.write_trade(sample_trade(-500_000, true));
+    writer.write_trade(sample_trade(1_000_000, false));
+    sleep(Duration::from_millis(80)).await;
+    writer.shutdown();
+    sleep(Duration::from_millis(50)).await;
+
+    let reader = DbReader::open(&path).expect("open reader");
+    let summary = reader.pnl_summary().expect("pnl_summary");
+    assert_eq!(summary.total_trades, 3);
+    assert_eq!(summary.wins, 2); // two positive
+    assert_eq!(summary.total_pnl_raw, 2_500_000);
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn recent_trades_limit() {
+    let (writer, _handle, path) = temp_db().await;
+
+    for i in 0..5i64 {
+        writer.write_trade(sample_trade(i * 100_000, true));
+    }
+    sleep(Duration::from_millis(80)).await;
+    writer.shutdown();
+    sleep(Duration::from_millis(50)).await;
+
+    let reader = DbReader::open(&path).expect("open reader");
+    let trades = reader.recent_trades(3).expect("recent_trades");
+    assert_eq!(trades.len(), 3, "limit should be respected");
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn schema_idempotent_reopen() {
+    let path = format!(
+        "/tmp/gate-arb-schema-test-{}.db",
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+
+    // Open twice — CREATE IF NOT EXISTS should not panic
+    {
+        let (w, _h) = DbWriter::open(&path).expect("first open");
+        w.write_trade(sample_trade(100, true));
+        sleep(Duration::from_millis(30)).await;
+        w.shutdown();
+        sleep(Duration::from_millis(30)).await;
+    }
+    {
+        let (w, _h) = DbWriter::open(&path).expect("second open");
+        w.write_trade(sample_trade(200, false));
+        sleep(Duration::from_millis(30)).await;
+        w.shutdown();
+        sleep(Duration::from_millis(30)).await;
+    }
+
+    let reader = DbReader::open(&path).expect("reader");
+    assert_eq!(reader.recent_trades(10).expect("trades").len(), 2);
+
+    let _ = std::fs::remove_file(path);
+}
+
+#[tokio::test]
+async fn write_spread_empty_db_returns_zero_pnl() {
+    let (writer, _handle, path) = temp_db().await;
+    writer.write_spread(sample_spread(1_000, false));
+    sleep(Duration::from_millis(50)).await;
+    writer.shutdown();
+    sleep(Duration::from_millis(30)).await;
+
+    let reader = DbReader::open(&path).expect("reader");
+    let summary = reader.pnl_summary().expect("pnl");
+    assert_eq!(summary.total_trades, 0);
+    assert_eq!(summary.total_pnl_raw, 0);
+
+    let _ = std::fs::remove_file(path);
+}

--- a/crates/strategy/Cargo.toml
+++ b/crates/strategy/Cargo.toml
@@ -6,5 +6,6 @@ edition.workspace = true
 [dependencies]
 types = { path = "../types" }
 engine = { path = "../engine" }
+db = { path = "../db" }
 parking_lot = { workspace = true }
 tracing = { workspace = true }

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -53,7 +53,7 @@ pub struct Strategy {
     /// Tick counter for summary printing.
     tick_counter: RwLock<u64>,
     /// Optional DB writer — write trade records and spread snapshots.
-    db: Option<DbWriter>,
+    db_writer: Option<DbWriter>,
 }
 
 impl Strategy {
@@ -71,13 +71,13 @@ impl Strategy {
             cumulative_pnl: RwLock::new(0),
             paper_stats: RwLock::new(PaperStats::default()),
             tick_counter: RwLock::new(0),
-            db: None,
+            db_writer: None,
         }
     }
 
     /// Wire in a DbWriter for trade and spread logging.
     pub fn set_db(&mut self, db: DbWriter) {
-        self.db = Some(db);
+        self.db_writer = Some(db);
     }
 
     /// Called every tick from the hot path — check spread, emit signals.
@@ -98,7 +98,7 @@ impl Strategy {
             }
 
             // Write spread snapshot to DB on every signal (sampled — only when threshold fires)
-            if let Some(ref db) = self.db {
+            if let Some(ref db) = self.db_writer {
                 db.write_spread(DbSpreadSnapshot {
                     ts_us: sig.timestamp_us,
                     spread_raw: sig.spread_raw as i64,
@@ -283,7 +283,7 @@ impl Strategy {
         );
 
         // Write trade record to DB
-        if let Some(ref db) = self.db {
+        if let Some(ref db) = self.db_writer {
             db.write_trade(TradeRecord {
                 opened_at_us: pos.opened_at_us,
                 closed_at_us: now,

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -13,6 +13,7 @@
 pub mod funding;
 pub use funding::FundingStrategy;
 
+use db::{DbWriter, SpreadSnapshot as DbSpreadSnapshot, TradeRecord};
 use engine::Engine;
 use parking_lot::RwLock;
 use std::sync::Arc;
@@ -51,6 +52,8 @@ pub struct Strategy {
     paper_stats: RwLock<PaperStats>,
     /// Tick counter for summary printing.
     tick_counter: RwLock<u64>,
+    /// Optional DB writer — write trade records and spread snapshots.
+    db: Option<DbWriter>,
 }
 
 impl Strategy {
@@ -68,7 +71,13 @@ impl Strategy {
             cumulative_pnl: RwLock::new(0),
             paper_stats: RwLock::new(PaperStats::default()),
             tick_counter: RwLock::new(0),
+            db: None,
         }
+    }
+
+    /// Wire in a DbWriter for trade and spread logging.
+    pub fn set_db(&mut self, db: DbWriter) {
+        self.db = Some(db);
     }
 
     /// Called every tick from the hot path — check spread, emit signals.
@@ -86,6 +95,17 @@ impl Strategy {
             {
                 let mut stats = self.paper_stats.write();
                 stats.last_signal_at_us = Some(sig.timestamp_us);
+            }
+
+            // Write spread snapshot to DB on every signal (sampled — only when threshold fires)
+            if let Some(ref db) = self.db {
+                db.write_spread(DbSpreadSnapshot {
+                    ts_us: sig.timestamp_us,
+                    spread_raw: sig.spread_raw as i64,
+                    inverted: false, // signal fires on positive spread only
+                    spot_price_raw: sig.bid_price.raw() as i64,
+                    perp_price_raw: sig.ask_price.raw() as i64,
+                });
             }
 
             if self.position.read().is_none() {
@@ -261,6 +281,27 @@ impl Strategy {
             pnl_after as f64 / SCALE as f64,
             hold_time / 1_000_000
         );
+
+        // Write trade record to DB
+        if let Some(ref db) = self.db {
+            db.write_trade(TradeRecord {
+                opened_at_us: pos.opened_at_us,
+                closed_at_us: now,
+                entry_price_raw: spot_buy_price as i64,
+                exit_price_raw: spot_exit_price as i64,
+                size_raw: qty as i64,
+                pnl_raw: trade_pnl_raw,
+                pnl_pct_raw: if spot_buy_price > 0 {
+                    (trade_pnl_raw as i128 * 1_000_000_i128
+                        / (spot_buy_price as i128 * qty as i128 / SCALE as i128))
+                        as i64
+                } else {
+                    0
+                },
+                exit_reason: reason.to_string(),
+                paper: self.paper_mode,
+            });
+        }
 
         pos.state = TradeState::Closed;
         *pos_guard = None;


### PR DESCRIPTION
## Changes (closes #11)

### New crate: crates/db

**Types:**
- `TradeRecord`: entry/exit timestamps (µs), prices, size, pnl_raw, pnl_pct_raw, exit_reason, paper flag
- `SpreadSnapshot`: ts_us, spread_raw, inverted, spot/perp prices (threshold-sampled, not every tick)
- `PnlSummary`: total_trades, wins, total_pnl_raw (serde::Serialize)

**DbWriter** — non-blocking async handle:
- `mpsc::channel(1024)` → background tokio task (Thread 3 / cold path)
- `write_trade()` / `write_spread()`: `try_send` — drops silently if channel full (hot-path safe, no blocking)
- `shutdown()`: Shutdown sentinel drains cleanly before task exits
- `DbWriter::from_env()`: reads `DB_PATH` (default: `gate-arb.db`)
- `Clone`: freely shareable across threads — all clones share same sender

**DbReader** — read-only connection (separate handle for query endpoints):
- WAL mode + `PRAGMA query_only = ON`
- `recent_trades(n)` / `recent_spreads(n)`: newest-first
- `pnl_summary()`: COALESCE guards on empty table (bug fix over old branch: SUM on 0 rows returned NULL → panic)

**open_db()**: WAL + NORMAL synchronous (safe performance tradeoff for local SQLite), CREATE IF NOT EXISTS (idempotent reopens), indexes on opened_at_us / ts_us

### Strategy wiring (crates/strategy/src/lib.rs)
- `set_db(DbWriter)`: optional injection before tick loop
- `on_tick_with_signal()`: `write_spread()` on every spread signal (threshold-gated — only fires when entry threshold exceeded, not on every book update)
- `paper_close_if_needed()`: `write_trade()` on close with full pnl_pct_raw calculation

### Tests — crates/db/tests/db_test.rs (6 tests, all green)
| Test | Covers |
|---|---|
| write_and_read_trade | round-trip single trade |
| write_and_read_spread | two snapshots, newest-first order |
| pnl_summary_correct | 3 trades, 2 wins, correct total_pnl |
| recent_trades_limit | limit param respected |
| schema_idempotent_reopen | open twice, no panic, 2 rows |
| write_spread_empty_db_returns_zero_pnl | no trades → pnl=0 (COALESCE fix) |

All 6 green. Full workspace tests green. Clippy clean.