### PR TITLE
feat(#26): Docker Compose deployment config + CI docker-lint + deploy script

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+target/
+*.md
+docs/
+.env
+Dockerfile
+docker-compose*.yml
+nginx.conf
+.cargo/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,33 @@
+# gate-arb environment configuration
+# Copy to .env and fill in values before running.
+#
+# All GATE_* variables are read at startup — no recompile needed.
+
+# === Trading symbols ===
+GATE_SPOT_SYMBOL=BTC_USDT
+GATE_PERP_SYMBOL=BTC_USDT
+
+# === Strategy parameters ===
+# Spread entry threshold in basis points (1 bps = 0.01%)
+# 5 bps ≈ $25 spread on BTC at $50k
+GATE_SPREAD_THRESHOLD_BPS=5
+
+# Max position size in USD (risk guard)
+GATE_MAX_POSITION_USD=1000
+
+# === Gate.io API keys (required in live mode; leave empty for paper mode) ===
+GATE_API_KEY=
+GATE_API_SECRET=
+
+# Risk limits
+GATE_MAX_DRAWDOWN_USD=10
+GATE_MAX_POSITIONS=3
+GATE_PING_THRESHOLD_MS=100
+
+# === Mode ===
+# Set to 'false' to enable live trading
+PAPER_MODE=true
+
+# === Ports ===
+GATE_FRONTEND_PORT=8080
+GATE_HEALTH_PORT=8081

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [main, fix/*]
+    branches: [main, fix/*, feat/*]
   pull_request:
     branches: [main]
 
@@ -44,3 +44,13 @@ jobs:
           else
             echo "Binary not found, skip size check"
           fi
+
+  docker-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lint Dockerfile (hadolint)
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: Dockerfile
+          failure-threshold: error

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,44 @@
+# Stage 1: builder — Debian-based to ensure openssl / native-tls works
+FROM rust:1.82-slim-bookworm AS builder
+
+# Install build deps for rustls (ring needs cc; libssl for native-tls fallback)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy workspace manifests first for layer caching
+COPY Cargo.toml Cargo.lock ./
+COPY crates ./crates
+# Stub src so cargo fetch/build can resolve workspace members
+RUN mkdir -p src && echo 'fn main(){}' > src/main.rs
+
+# Fetch deps (cache layer)
+RUN cargo fetch --locked
+
+# Now copy real source and build
+COPY src ./src
+RUN cargo build --release --locked --bin gate-arb
+
+# Stage 2: minimal runtime — uses debian slim for ca-certs + healthcheck
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -r -s /bin/false gate-arb
+
+COPY --from=builder /app/target/release/gate-arb /usr/local/bin/gate-arb
+
+# Health check via curl (available in runtime image)
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+    CMD curl -sf http://localhost:8081/health || exit 1
+
+USER gate-arb
+EXPOSE 8080 8081
+
+ENTRYPOINT ["/usr/local/bin/gate-arb"]

--- a/crates/strategy/tests/order_wiring_test.rs
+++ b/crates/strategy/tests/order_wiring_test.rs
@@ -1,0 +1,181 @@
+//! Tests for live order wiring in strategy:
+//! - set_order_sender() is accepted
+//! - open_position() sends LEG1 OrderCmd when not paper_mode
+//! - on_order_ack(Filled, leg1) triggers LEG2 send + state = Leg2Sent
+//! - on_order_ack(Filled, leg2) → state = BothFilled
+//! - on_order_ack(Cancelled) → state = Closing
+
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use types::{Fixed64, LegKind, OrderAck, OrderStatus, SpreadSignal, TradeState};
+
+fn make_strategy_live() -> (Arc<strategy::Strategy>, mpsc::Receiver<types::OrderCmd>) {
+    let engine = Arc::new(engine::Engine::<20, 20>::new());
+    let mut s = strategy::Strategy::new(Arc::clone(&engine), 0);
+    s.paper_mode = false;
+    let s = Arc::new(s);
+    let (tx, rx) = mpsc::channel(32);
+    s.set_order_sender(tx);
+    (s, rx)
+}
+
+fn spread_signal() -> SpreadSignal {
+    SpreadSignal {
+        spread_raw: 1_000_000,
+        spread_pct: Fixed64::from_raw(0),
+        bid_price: Fixed64::from_float(50000.0),
+        ask_price: Fixed64::from_float(50010.0),
+        timestamp_us: 1_000_000,
+    }
+}
+
+#[tokio::test]
+async fn live_open_sends_leg1_order() {
+    let (s, mut rx) = make_strategy_live();
+
+    // Manually trigger open_position via on_tick_with_signal
+    let sig = spread_signal();
+    // We need position to be None (it is by default)
+    // Inject signal directly
+    s.on_tick_with_signal(Some(sig));
+
+    // Expect LEG1 OrderCmd::Place to be sent
+    let cmd = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+        .await
+        .expect("timed out waiting for cmd")
+        .expect("channel closed");
+
+    match cmd {
+        types::OrderCmd::Place {
+            side,
+            post_only,
+            qty,
+            ..
+        } => {
+            assert_eq!(side, types::Side::Bid, "leg1 must be spot BUY");
+            assert!(post_only, "must be post-only");
+            assert_eq!(qty, 1_000_000, "qty must be 1e6 units = 0.01 BTC");
+        }
+        other => panic!("expected Place, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn on_order_ack_leg1_filled_sends_leg2() {
+    let (s, mut rx) = make_strategy_live();
+
+    // Open position
+    s.on_tick_with_signal(Some(spread_signal()));
+
+    // Drain leg1 cmd
+    let leg1_cmd = rx.recv().await.expect("leg1 cmd");
+    let leg1_client_id = match leg1_cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!("expected Place"),
+    };
+
+    // Simulate LEG1 filled
+    s.on_order_ack(OrderAck {
+        client_id: leg1_client_id,
+        exchange_id: "ex-111".to_string(),
+        status: OrderStatus::Filled,
+    });
+
+    // Should receive LEG2 cmd
+    let leg2_cmd = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+        .await
+        .expect("timed out waiting for leg2")
+        .expect("channel closed");
+
+    match leg2_cmd {
+        types::OrderCmd::Place {
+            client_id,
+            side,
+            post_only,
+            ..
+        } => {
+            assert_eq!(side, types::Side::Ask, "leg2 must be perp SHORT (sell)");
+            assert!(post_only, "leg2 must be post-only");
+            assert_eq!(client_id % 2, 1, "leg2 client_id must be odd");
+        }
+        other => panic!("expected Place for leg2, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn on_order_ack_leg2_filled_both_filled() {
+    let (s, mut rx) = make_strategy_live();
+
+    s.on_tick_with_signal(Some(spread_signal()));
+    let leg1_cmd = rx.recv().await.unwrap();
+    let leg1_id = match leg1_cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!(),
+    };
+
+    // Fill leg1 → sends leg2
+    s.on_order_ack(OrderAck {
+        client_id: leg1_id,
+        exchange_id: "e1".into(),
+        status: OrderStatus::Filled,
+    });
+    let leg2_cmd = rx.recv().await.unwrap();
+    let leg2_id = match leg2_cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!(),
+    };
+
+    // Fill leg2 → BOTH_FILLED
+    s.on_order_ack(OrderAck {
+        client_id: leg2_id,
+        exchange_id: "e2".into(),
+        status: OrderStatus::Filled,
+    });
+
+    // Position state should be BothFilled
+    assert!(
+        s.is_position_open(),
+        "position should still be open (BOTH_FILLED, not CLOSED)"
+    );
+}
+
+#[tokio::test]
+async fn on_order_ack_cancelled_triggers_closing() {
+    let (s, mut rx) = make_strategy_live();
+
+    s.on_tick_with_signal(Some(spread_signal()));
+    let cmd = rx.recv().await.unwrap();
+    let client_id = match cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!(),
+    };
+
+    // Post-only rejection
+    s.on_order_ack(OrderAck {
+        client_id,
+        exchange_id: "".into(),
+        status: OrderStatus::Cancelled,
+    });
+
+    // Position should exist but be in Closing state
+    assert!(s.is_position_open(), "position guard still holds");
+}
+
+#[tokio::test]
+async fn paper_mode_does_not_send_orders() {
+    let engine = Arc::new(engine::Engine::<20, 20>::new());
+    let s = Arc::new(strategy::Strategy::new(Arc::clone(&engine), 0));
+    // paper_mode = true (default), no order_sender set
+
+    let (tx, mut rx) = mpsc::channel::<types::OrderCmd>(32);
+    // Don't call set_order_sender — no channel wired
+
+    s.on_tick_with_signal(Some(spread_signal()));
+
+    // No cmd should arrive (paper mode uses paper_open_position, not open_position)
+    let result = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+    assert!(result.is_err(), "paper mode must not send any OrderCmd");
+
+    // Suppress unused warning
+    drop(tx);
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,57 @@
+services:
+  gate-arb:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ghcr.io/ddfeyes/gate-arb:latest
+    container_name: gate-arb
+    restart: unless-stopped
+    ports:
+      - "8081:8081"   # health endpoint — always exposed
+      # Frontend WS — optional, uncomment for local dashboard access
+      # - "8080:8080"
+    env_file:
+      - .env
+    environment:
+      # Trading symbols (GATE_* prefix; fallback: SPOT_SYMBOL / PERP_SYMBOL)
+      GATE_SPOT_SYMBOL: ${GATE_SPOT_SYMBOL:-BTC_USDT}
+      GATE_PERP_SYMBOL: ${GATE_PERP_SYMBOL:-BTC_USDT}
+      # Strategy
+      GATE_SPREAD_THRESHOLD_BPS: ${GATE_SPREAD_THRESHOLD_BPS:-5}
+      GATE_MAX_POSITION_USD: ${GATE_MAX_POSITION_USD:-1000}
+      # Gate.io API keys (required in live mode)
+      GATE_API_KEY: ${GATE_API_KEY:-}
+      GATE_API_SECRET: ${GATE_API_SECRET:-}
+      # Paper mode (default: true — no real orders)
+      PAPER_MODE: ${PAPER_MODE:-true}
+      # Ports
+      GATE_FRONTEND_PORT: "8080"
+      GATE_HEALTH_PORT: "8081"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8081/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    deploy:
+      resources:
+        limits:
+          memory: 256M   # HFT hot path — fixed-size ring buffers, no heap growth
+
+  # nginx reverse-proxy for https://gate-arb.111miniapp.com/
+  # Activate with: docker compose --profile production up
+  nginx:
+    image: nginx:1.27-alpine
+    container_name: gate-arb-nginx
+    restart: unless-stopped
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./certs:/etc/nginx/certs:ro
+    depends_on:
+      gate-arb:
+        condition: service_healthy
+    profiles:
+      - production

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,67 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    # Upstream for gate-arb frontend WS + dashboard
+    upstream gate_arb_ws {
+        server gate-arb:8080;
+        keepalive 32;
+    }
+
+    # Rate limiting — protect health endpoint from monitoring storms
+    limit_req_zone $binary_remote_addr zone=health:10m rate=10r/s;
+
+    # HTTP — redirect to HTTPS in production
+    server {
+        listen 80;
+        server_name gate-arb.111miniapp.com;
+        return 301 https://$host$request_uri;
+    }
+
+    # HTTPS — proxy WebSocket dashboard
+    server {
+        listen 443 ssl;
+        server_name gate-arb.111miniapp.com;
+
+        # SSL certificates — bind-mount ./certs at container runtime
+        # Generate with: certbot certonly --webroot -d gate-arb.111miniapp.com
+        ssl_certificate     /etc/nginx/certs/fullchain.pem;
+        ssl_certificate_key /etc/nginx/certs/privkey.pem;
+        ssl_protocols       TLSv1.2 TLSv1.3;
+        ssl_ciphers         HIGH:!aNULL:!MD5;
+        ssl_prefer_server_ciphers on;
+        ssl_session_cache   shared:SSL:10m;
+        ssl_session_timeout 10m;
+
+        # Security headers
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Content-Type-Options    "nosniff" always;
+        add_header X-Frame-Options           "SAMEORIGIN" always;
+
+        # Health check — no auth, rate-limited
+        location = /health {
+            limit_req zone=health burst=5;
+            proxy_pass         http://gate_arb_ws;
+            proxy_http_version 1.1;
+            proxy_read_timeout 5s;
+        }
+
+        # Dashboard HTML + WS upgrade
+        location / {
+            proxy_pass         http://gate_arb_ws;
+            proxy_http_version 1.1;
+            proxy_set_header   Upgrade $http_upgrade;
+            proxy_set_header   Connection "upgrade";
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+
+            # WS keepalive: re-subscribe on reconnect within 120s
+            proxy_read_timeout  120s;
+            proxy_send_timeout  120s;
+            proxy_connect_timeout 5s;
+        }
+    }
+}

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# deploy.sh — deploy gate-arb to Hetzner via SSH.
+#
+# Usage:
+#   ./scripts/deploy.sh [--profile production]
+#
+# Prerequisites:
+#   - SSH access to Hetzner (source ~/.lain-secrets/hetzner.env first)
+#   - Docker + docker compose v2 on remote
+#   - .env file on remote at /home/user3/gate-arb/.env
+#
+# What it does:
+#   1. rsync repo (excluding target/) to Hetzner
+#   2. docker compose build + up -d on remote
+#   3. Tail health endpoint to confirm startup
+
+set -euo pipefail
+
+source ~/.lain-secrets/hetzner.env 2>/dev/null || true
+
+REMOTE_HOST="${HETZNER_HOST:-}"
+REMOTE_USER="${HETZNER_USER:-user3}"
+REMOTE_DIR="/home/${REMOTE_USER}/gate-arb"
+PROFILE="${1:-}"
+
+if [[ -z "$REMOTE_HOST" ]]; then
+  echo "ERROR: HETZNER_HOST not set. Source ~/.lain-secrets/hetzner.env or set HETZNER_HOST." >&2
+  exit 1
+fi
+
+echo "==> Syncing to ${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DIR}"
+rsync -avz --exclude='.git' --exclude='target/' --exclude='.env' \
+  ./ "${REMOTE_USER}@${REMOTE_HOST}:${REMOTE_DIR}/"
+
+echo "==> Building and starting on remote"
+# shellcheck disable=SC2029
+ssh "${REMOTE_USER}@${REMOTE_HOST}" bash -s <<ENDSSH
+set -euo pipefail
+cd "${REMOTE_DIR}"
+
+# Build image
+docker compose build gate-arb
+
+# Rotate: stop old, clean old images
+docker compose down --remove-orphans || true
+docker image prune -f
+
+# Start (with optional production profile for nginx)
+if [[ -n "${PROFILE}" ]]; then
+  docker compose --profile production up -d
+else
+  docker compose up -d gate-arb
+fi
+
+echo "Waiting for health check..."
+for i in \$(seq 1 20); do
+  if curl -sf http://localhost:8081/health > /dev/null 2>&1; then
+    echo "Health check passed after \${i}s"
+    break
+  fi
+  sleep 1
+done
+
+curl -s http://localhost:8081/health | python3 -m json.tool || true
+ENDSSH
+
+echo "==> Deploy complete: https://gate-arb.111miniapp.com/"


### PR DESCRIPTION
## Resolves

Closes #26 (deployment blockers — resolve #12 + #14)
Supersedes #19 (was CONFLICTING against main)

## What's included

### Dockerfile (fixed from PR #19)
- Builder: `rust:1.82-slim-bookworm` (debian, not Alpine) — avoids musl/ring build issues with `rustls-tls-webpki-roots`
- Runtime: `debian:bookworm-slim` — curl healthcheck, nonroot user, ca-certs
- Proper layer caching: manifests + crates first, then src

### docker-compose.yml
- Env vars aligned with `GATE_*` prefix from `config.rs` (not legacy SPOT_SYMBOL/GATE_SECRET)
- gate-arb + nginx (activated with `--profile production`)
- health check via `curl` (matches runtime image)
- 256M memory limit

### .env.example
- Full reference with `GATE_*` vars + risk limits (`GATE_MAX_DRAWDOWN_USD` etc.)

### nginx.conf
- HTTP → HTTPS redirect
- WS upgrade for dashboard
- SSL headers, rate-limit on /health

### CI (.github/workflows/ci.yml)
- Added `feat/*` to push trigger branches
- New `docker-lint` job (hadolint, error-threshold only)

### scripts/deploy.sh
- rsync → remote build → docker compose up → health check wait

## Notes
- Issue #14 (hardcoded symbols) was already resolved in main via `config.rs` GATE_* env vars — no code change needed
- Old PR #19 branch was ~20 commits behind main (CONFLICTING) — files cherry-picked and corrected