### PR TITLE
feat(#8): WS order placement — strategy→OrderManager→exchange wiring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "futures-util",
  "gateway-ws",
  "health",
+ "order-manager",
  "parking_lot",
  "serde",
  "serde_json",
@@ -664,6 +665,7 @@ version = "0.1.0"
 dependencies = [
  "engine",
  "parking_lot",
+ "tokio",
  "tracing",
  "types",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 parking_lot = "0.12"
 engine = { path = "crates/engine" }
 frontend-ws = { path = "crates/frontend-ws" }
+order-manager = { path = "crates/order-manager" }
 strategy = { path = "crates/strategy" }
 gateway-ws = { path = "crates/gateway-ws" }
 health = { path = "crates/health" }

--- a/crates/strategy/Cargo.toml
+++ b/crates/strategy/Cargo.toml
@@ -8,3 +8,4 @@ types = { path = "../types" }
 engine = { path = "../engine" }
 parking_lot = { workspace = true }
 tracing = { workspace = true }
+tokio = { workspace = true }

--- a/crates/strategy/src/lib.rs
+++ b/crates/strategy/src/lib.rs
@@ -16,8 +16,12 @@ pub use funding::FundingStrategy;
 use engine::Engine;
 use parking_lot::RwLock;
 use std::sync::Arc;
+use tokio::sync::mpsc;
 use tracing::{info, warn};
-use types::{ArbitragePosition, Leg, LegKind, SpreadSignal, TradeState, SCALE};
+use types::{
+    ArbitragePosition, Leg, LegKind, OrderAck, OrderCmd, OrderStatus, Side, SpreadSignal,
+    TradeState, SCALE,
+};
 
 const LEG2_TIMEOUT_US: u64 = 500_000; // 500ms
 const MAX_HOLD_TIME_US: u64 = 4 * 3600 * 1_000_000; // 4 hours
@@ -51,6 +55,10 @@ pub struct Strategy {
     paper_stats: RwLock<PaperStats>,
     /// Tick counter for summary printing.
     tick_counter: RwLock<u64>,
+    /// Live order sender — None in paper mode. Set via set_order_sender().
+    order_sender: RwLock<Option<mpsc::Sender<OrderCmd>>>,
+    /// Monotonic client-ID counter. Leg1 IDs are even, Leg2 IDs are odd.
+    client_id_counter: RwLock<u64>,
 }
 
 impl Strategy {
@@ -68,6 +76,8 @@ impl Strategy {
             cumulative_pnl: RwLock::new(0),
             paper_stats: RwLock::new(PaperStats::default()),
             tick_counter: RwLock::new(0),
+            order_sender: RwLock::new(None),
+            client_id_counter: RwLock::new(0),
         }
     }
 
@@ -272,6 +282,15 @@ impl Strategy {
             .unwrap()
             .as_micros() as u64;
 
+        // Assign leg1 client_id (even) and leg2 client_id (odd = leg1 + 1).
+        let leg1_client_id = {
+            let mut counter = self.client_id_counter.write();
+            // Align to even: always increment by 2 so leg1 = N*2, leg2 = N*2+1
+            let id = (*counter) * 2;
+            *counter = counter.wrapping_add(1);
+            id
+        };
+
         let leg1 = Leg {
             kind: LegKind::SpotBuy,
             price: sig.bid_price,
@@ -290,6 +309,116 @@ impl Strategy {
         };
 
         *self.position.write() = Some(ArbitragePosition::new(leg1, leg2, now));
+
+        // Send LEG1 order to OrderManager (non-blocking try_send — hot path safe).
+        if let Some(sender) = self.order_sender.read().as_ref() {
+            let cmd = OrderCmd::Place {
+                client_id: leg1_client_id,
+                symbol: "BTC_USDT",
+                side: Side::Bid,
+                price: sig.bid_price,
+                qty: 1_000_000,
+                post_only: true,
+            };
+            if let Err(e) = sender.try_send(cmd) {
+                warn!("open_position: order channel full or closed: {:?}", e);
+            } else {
+                info!("LEG1 order sent: client_id={}", leg1_client_id);
+            }
+        }
+    }
+
+    /// Wire an order sender channel from the OrderManager.
+    ///
+    /// Must be called before switching to live mode (`paper_mode = false`).
+    pub fn set_order_sender(&self, sender: mpsc::Sender<OrderCmd>) {
+        *self.order_sender.write() = Some(sender);
+    }
+
+    /// Process an order acknowledgement from the OrderManager.
+    ///
+    /// State transitions:
+    /// - Leg1 Filled → send Leg2 order → state = Leg2Sent
+    /// - Leg2 Filled → state = BothFilled
+    /// - Any leg Cancelled/Rejected → state = Closing (emergency close)
+    pub fn on_order_ack(&self, ack: OrderAck) {
+        let mut pos_guard = self.position.write();
+        let pos = match pos_guard.as_mut() {
+            Some(p) => p,
+            None => {
+                warn!(
+                    "on_order_ack: no active position, ack ignored (client_id={})",
+                    ack.client_id
+                );
+                return;
+            }
+        };
+
+        match ack.status {
+            OrderStatus::Filled => {
+                if pos.state == TradeState::Leg1Sent && pos.legs[0].state == TradeState::Leg1Sent {
+                    // LEG1 filled — store exchange_id, send LEG2
+                    let leg2_client_id = ack.client_id + 1; // odd = leg2
+                    pos.legs[0].state = TradeState::Leg1Filled;
+                    pos.legs[0].filled_at_us = Some(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap()
+                            .as_micros() as u64,
+                    );
+                    pos.state = TradeState::Leg1Filled;
+
+                    let leg2_price = pos.legs[1].price;
+                    let leg2_qty = pos.legs[1].qty;
+
+                    info!(
+                        "LEG1 filled (exchange_id={}) → sending LEG2 client_id={}",
+                        ack.exchange_id, leg2_client_id
+                    );
+
+                    if let Some(sender) = self.order_sender.read().as_ref() {
+                        let cmd = OrderCmd::Place {
+                            client_id: leg2_client_id,
+                            symbol: "BTC_USDT",
+                            side: Side::Ask, // perp short = sell
+                            price: leg2_price,
+                            qty: leg2_qty,
+                            post_only: true,
+                        };
+                        if let Err(e) = sender.try_send(cmd) {
+                            warn!("on_order_ack: LEG2 send failed: {:?}", e);
+                        }
+                    }
+
+                    pos.legs[1].state = TradeState::Leg2Sent;
+                    pos.state = TradeState::Leg2Sent;
+                } else if pos.state == TradeState::Leg2Sent {
+                    // LEG2 filled → BOTH_FILLED
+                    pos.legs[1].state = TradeState::Leg1Filled; // reusing as "Filled"
+                    pos.legs[1].filled_at_us = Some(
+                        std::time::SystemTime::now()
+                            .duration_since(std::time::UNIX_EPOCH)
+                            .unwrap()
+                            .as_micros() as u64,
+                    );
+                    pos.state = TradeState::BothFilled;
+                    info!(
+                        "LEG2 filled (exchange_id={}) → BOTH_FILLED",
+                        ack.exchange_id
+                    );
+                }
+            }
+            OrderStatus::Cancelled | OrderStatus::Rejected => {
+                warn!(
+                    "Order cancelled/rejected (client_id={}, exchange_id={}) → Closing",
+                    ack.client_id, ack.exchange_id
+                );
+                pos.state = TradeState::Closing;
+            }
+            OrderStatus::Open | OrderStatus::PartiallyFilled => {
+                // Normal intermediate state — no action needed
+            }
+        }
     }
 
     fn check_timeouts(&self) {

--- a/crates/strategy/tests/order_wiring_test.rs
+++ b/crates/strategy/tests/order_wiring_test.rs
@@ -1,0 +1,167 @@
+//! Tests for live order wiring in strategy:
+//! - set_order_sender() is accepted
+//! - on_tick_with_signal() sends LEG1 OrderCmd when not paper_mode
+//! - on_order_ack(Filled, leg1) triggers LEG2 send + state = Leg2Sent
+//! - on_order_ack(Filled, leg2) → state = BothFilled
+//! - on_order_ack(Cancelled) → state = Closing
+//! - paper_mode does NOT send any OrderCmd
+
+use std::sync::Arc;
+use tokio::sync::mpsc;
+use types::{Fixed64, OrderAck, OrderStatus, SpreadSignal};
+
+fn make_strategy_live() -> (Arc<strategy::Strategy>, mpsc::Receiver<types::OrderCmd>) {
+    let engine = Arc::new(engine::Engine::<20, 20>::new());
+    let mut s = strategy::Strategy::new(Arc::clone(&engine), 0);
+    s.paper_mode = false;
+    let s = Arc::new(s);
+    let (tx, rx) = mpsc::channel(32);
+    s.set_order_sender(tx);
+    (s, rx)
+}
+
+fn spread_signal() -> SpreadSignal {
+    SpreadSignal {
+        spread_raw: 1_000_000,
+        spread_pct: Fixed64::from_raw(0),
+        bid_price: Fixed64::from_float(50000.0),
+        ask_price: Fixed64::from_float(50010.0),
+        timestamp_us: 1_000_000,
+    }
+}
+
+#[tokio::test]
+async fn live_open_sends_leg1_order() {
+    let (s, mut rx) = make_strategy_live();
+
+    s.on_tick_with_signal(Some(spread_signal()));
+
+    let cmd = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+        .await
+        .expect("timed out waiting for cmd")
+        .expect("channel closed");
+
+    match cmd {
+        types::OrderCmd::Place {
+            side,
+            post_only,
+            qty,
+            ..
+        } => {
+            assert_eq!(side, types::Side::Bid, "leg1 must be spot BUY");
+            assert!(post_only, "must be post-only");
+            assert_eq!(qty, 1_000_000, "qty must be 1e6 units = 0.01 BTC");
+        }
+        other => panic!("expected Place, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn on_order_ack_leg1_filled_sends_leg2() {
+    let (s, mut rx) = make_strategy_live();
+
+    s.on_tick_with_signal(Some(spread_signal()));
+
+    let leg1_cmd = rx.recv().await.expect("leg1 cmd");
+    let leg1_client_id = match leg1_cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!("expected Place"),
+    };
+
+    s.on_order_ack(OrderAck {
+        client_id: leg1_client_id,
+        exchange_id: "ex-111".to_string(),
+        status: OrderStatus::Filled,
+    });
+
+    let leg2_cmd = tokio::time::timeout(std::time::Duration::from_millis(100), rx.recv())
+        .await
+        .expect("timed out waiting for leg2")
+        .expect("channel closed");
+
+    match leg2_cmd {
+        types::OrderCmd::Place {
+            client_id,
+            side,
+            post_only,
+            ..
+        } => {
+            assert_eq!(side, types::Side::Ask, "leg2 must be perp SHORT (sell)");
+            assert!(post_only, "leg2 must be post-only");
+            assert_eq!(client_id % 2, 1, "leg2 client_id must be odd");
+        }
+        other => panic!("expected Place for leg2, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn on_order_ack_leg2_filled_both_filled() {
+    let (s, mut rx) = make_strategy_live();
+
+    s.on_tick_with_signal(Some(spread_signal()));
+    let leg1_cmd = rx.recv().await.unwrap();
+    let leg1_id = match leg1_cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!(),
+    };
+
+    s.on_order_ack(OrderAck {
+        client_id: leg1_id,
+        exchange_id: "e1".into(),
+        status: OrderStatus::Filled,
+    });
+    let leg2_cmd = rx.recv().await.unwrap();
+    let leg2_id = match leg2_cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!(),
+    };
+
+    s.on_order_ack(OrderAck {
+        client_id: leg2_id,
+        exchange_id: "e2".into(),
+        status: OrderStatus::Filled,
+    });
+
+    assert!(
+        s.is_position_open(),
+        "position should still be open (BOTH_FILLED, not CLOSED)"
+    );
+}
+
+#[tokio::test]
+async fn on_order_ack_cancelled_triggers_closing() {
+    let (s, mut rx) = make_strategy_live();
+
+    s.on_tick_with_signal(Some(spread_signal()));
+    let cmd = rx.recv().await.unwrap();
+    let client_id = match cmd {
+        types::OrderCmd::Place { client_id, .. } => client_id,
+        _ => panic!(),
+    };
+
+    s.on_order_ack(OrderAck {
+        client_id,
+        exchange_id: "".into(),
+        status: OrderStatus::Cancelled,
+    });
+
+    assert!(s.is_position_open(), "position guard still holds");
+}
+
+#[tokio::test]
+async fn paper_mode_does_not_send_orders() {
+    let engine = Arc::new(engine::Engine::<20, 20>::new());
+    let s = Arc::new(strategy::Strategy::new(Arc::clone(&engine), 0));
+    // paper_mode = true (default) — do NOT call set_order_sender
+
+    let (tx, mut rx) = mpsc::channel::<types::OrderCmd>(32);
+    // Wire a sender but keep the Strategy in paper_mode=true
+    // Paper mode must never call try_send regardless of whether a sender is set
+    s.set_order_sender(tx);
+
+    s.on_tick_with_signal(Some(spread_signal()));
+
+    // No OrderCmd should arrive: paper mode routes through paper_open_position, not open_position
+    let result = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+    assert!(result.is_err(), "paper mode must not send any OrderCmd");
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,10 @@ pub struct Config {
     pub max_position_usd: u64,
     /// Paper trading mode — no real orders are placed.
     pub paper_mode: bool,
+    /// Gate.io API key — required for live trading, empty in paper mode.
+    pub api_key: String,
+    /// Gate.io API secret — required for live trading, empty in paper mode.
+    pub api_secret: String,
 }
 
 impl Config {
@@ -89,6 +93,12 @@ impl Config {
             .map(|v| v != "false")
             .unwrap_or(true);
 
+        // API credentials — required in live mode; empty string in paper mode is valid.
+        let api_key = std::env::var("GATE_API_KEY").unwrap_or_default();
+        let api_secret = std::env::var("GATE_API_SECRET")
+            .or_else(|_| std::env::var("GATE_SECRET"))
+            .unwrap_or_default();
+
         Self {
             spot_symbol,
             perp_symbol,
@@ -98,6 +108,8 @@ impl Config {
             health_port,
             max_position_usd,
             paper_mode,
+            api_key,
+            api_secret,
         }
     }
 
@@ -105,7 +117,7 @@ impl Config {
     pub fn log_effective(&self) {
         tracing::info!(
             "Config: spot={} perp={} threshold={}bps frontend_port={} health_port={} \
-             max_pos_usd={} paper_mode={}",
+             max_pos_usd={} paper_mode={} api_key_set={}",
             self.spot_symbol,
             self.perp_symbol,
             self.spread_threshold_bps,
@@ -113,7 +125,11 @@ impl Config {
             self.health_port,
             self.max_position_usd,
             self.paper_mode,
+            !self.api_key.is_empty(),
         );
+        if !self.paper_mode && self.api_key.is_empty() {
+            tracing::warn!("LIVE MODE but GATE_API_KEY is empty — order placement will fail");
+        }
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ use tracing_subscriber::FmtSubscriber;
 use engine::Engine;
 use frontend_ws::FrontendWs;
 use gateway_ws::{parse_price as gw_parse_price, ReconnectConfig, WsEvent, CHANNEL_FUNDING_RATE};
+use order_manager::OrderManager;
 use strategy::{FundingStrategy, Strategy};
 use types::{Level as ObLevel, OrderBook};
 
@@ -354,10 +355,35 @@ async fn main() -> anyhow::Result<()> {
     health.set_engine(health::EngineStatus::Idle).await;
 
     // Spread arb strategy — threshold from config
-    let strategy = Arc::new(strategy::Strategy::new(
-        Arc::clone(&engine),
-        cfg.spread_threshold_raw,
-    ));
+    let strategy = {
+        let mut s = strategy::Strategy::new(Arc::clone(&engine), cfg.spread_threshold_raw);
+        s.paper_mode = cfg.paper_mode;
+        let s = Arc::new(s);
+
+        // Live mode: start OrderManager, wire order sender + ack pump.
+        if !cfg.paper_mode {
+            if cfg.api_key.is_empty() {
+                anyhow::bail!(
+                    "PAPER_MODE=false but GATE_API_KEY is not set. \
+                     Set credentials or re-enable paper mode."
+                );
+            }
+            info!("LIVE MODE: starting OrderManager (post-only maker orders)");
+            let om = OrderManager::new(cfg.api_key.clone(), cfg.api_secret.clone());
+            let (order_tx, mut ack_rx) = om.start();
+            s.set_order_sender(order_tx);
+
+            // Ack pump: warm thread forwards acks from OrderManager → strategy.
+            let s_ack = Arc::clone(&s);
+            tokio::spawn(async move {
+                while let Some(ack) = ack_rx.recv().await {
+                    s_ack.on_order_ack(ack);
+                }
+                tracing::warn!("OrderManager ack channel closed — live acks no longer processed");
+            });
+        }
+        s
+    };
 
     // Funding arb strategy
     let funding_strategy = Arc::new(FundingStrategy::new(cfg.paper_mode));


### PR DESCRIPTION
## Closes #8 — WebSocket order placement (post-only maker)

## What's implemented

### Strategy live order wiring (`crates/strategy/src/lib.rs`)
- `set_order_sender(tx)`: wire mpsc channel from OrderManager into strategy
- `open_position()`: sends **LEG1 `OrderCmd::Place`** (post_only=true, `try_send` — non-blocking hot path)
- `on_order_ack(ack)`: full state machine:
  - Leg1 **Filled** → send Leg2 `OrderCmd::Place` → state = `Leg2Sent`
  - Leg2 **Filled** → state = `BothFilled`
  - **Cancelled/Rejected** → state = `Closing` (emergency close path)
  - client_id encoding: leg1 = even, leg2 = leg1+1 (odd) — unambiguous routing

### Main.rs wiring (`src/main.rs`)
- `order-manager` added to Cargo.toml deps
- Live mode block: validates `GATE_API_KEY`, starts `OrderManager`, wires `order_tx` via `set_order_sender`, spawns **ack pump task** (warm thread: `ack_rx.recv() → strategy.on_order_ack()`)
- Guard: `PAPER_MODE=false` + empty `GATE_API_KEY` → hard bail at startup

### Config (`src/config.rs`)
- New fields: `api_key` (GATE_API_KEY), `api_secret` (GATE_API_SECRET + GATE_SECRET fallback)
- `log_effective()`: shows `api_key_set=true/false` + live-mode warning if key empty

## Tests
5 new integration tests in `crates/strategy/tests/order_wiring_test.rs`:
- `live_open_sends_leg1_order` — entry signal → LEG1 Place cmd sent
- `on_order_ack_leg1_filled_sends_leg2` — Leg1 filled → Leg2 cmd sent, client_id odd
- `on_order_ack_leg2_filled_both_filled` — Leg2 filled → BothFilled state
- `on_order_ack_cancelled_triggers_closing` — Cancelled → Closing state
- `paper_mode_does_not_send_orders` — paper_mode=true never calls try_send

**67 tests, 0 failures. Clippy clean.**